### PR TITLE
Extended TLS testing with mutual TLS setup

### DIFF
--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
@@ -9,7 +9,16 @@ import io.github.jopenlibs.vault.VaultException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.certs.CertificateFiles;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.PemCertificateFiles;
+
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -123,5 +132,51 @@ public class VaultConnectorHttpsTestCase {
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", "admin", httpsSslConfig, true);
         vaultService.configure();
         vaultService.removeSecret("secret/testing1", "top_secret");
+    }
+
+    /**
+     * Verify that connection fails when the client trusts a different CA than the one that issued
+     * the Vault server certificate. The SSL handshake should be rejected.
+     */
+    @Test
+    public void testConnectionFailsWithUntrustedServerCert() throws Exception {
+        startVaultTestContainer();
+
+        Path wrongCertDir = Files.createTempDirectory("wrong_certs");
+        try {
+            CertificateRequest request = new CertificateRequest()
+                    .withName("wrong")
+                    .withPassword("secret")
+                    .withClientCertificate()
+                    .withFormat(Format.PEM);
+            List<CertificateFiles> wrongCerts = new CertificateGenerator(wrongCertDir, true).generate(request);
+            PemCertificateFiles wrongPem = (PemCertificateFiles) wrongCerts.stream()
+                    .filter(f -> f instanceof PemCertificateFiles).findFirst().get();
+
+            SslConfig wrongTrustConfig = new SslConfig()
+                    .pemFile(wrongPem.trustFile().toFile())
+                    .verify(true)
+                    .build();
+
+            VaultConnector vaultService = new VaultConnector(
+                    vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", wrongTrustConfig, true);
+            assertThrows(VaultException.class, vaultService::configure);
+        } finally {
+            VaultTestUtils.cleanupDir(wrongCertDir);
+        }
+    }
+
+    /**
+     * Verify that connection fails when SSL verification is enabled but no trust PEM is configured.
+     * The self-signed Vault certificate is not trusted by the JVM default trust store.
+     */
+    @Test
+    public void testConnectionFailsWithNoTrustConfigured() throws Exception {
+        startVaultTestContainer();
+
+        SslConfig noTrustConfig = new SslConfig().verify(true).build();
+        VaultConnector vaultService = new VaultConnector(
+                vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", noTrustConfig, true);
+        assertThrows(VaultException.class, vaultService::configure);
     }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorMutualTlsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorMutualTlsTestCase.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
+import io.smallrye.certs.CertificateFiles;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.PemCertificateFiles;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wildfly.security.hashicorp.vault.auth.TlsCertAuthConfig;
+
+import javax.net.ssl.SSLContext;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Negative TLS tests with mutual TLS enforcement ({@code tls_require_and_verify_client_cert = true}).
+ * Vault rejects connections at the TLS handshake level when a valid client certificate is not presented.
+ */
+public class VaultConnectorMutualTlsTestCase {
+
+    private VaultContainerHttps<?> vaultTestContainer;
+    private SslConfig permissibleSslConfig;
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        vaultTestContainer = new VaultContainerHttps<>("hashicorp/vault:1.13", true)
+                .withVaultToken("myroot")
+                .withInitCommand(
+                        "secrets enable transit",
+                        "write -f transit/keys/my-key",
+                        "kv put secret/testing1 ttl=30m top_secret=password123"
+                );
+
+        new TlsCertAuthConfig.Builder(vaultTestContainer.getClientCertificateFiles())
+                .policies("admin")
+                .build()
+                .configure(vaultTestContainer);
+
+        vaultTestContainer.start();
+
+        permissibleSslConfig = new SslConfig()
+                .pemFile(vaultTestContainer.getHttpsTrustFile().toFile())
+                .clientPemFile(vaultTestContainer.getClientCertificateFiles().clientCertFile().toFile())
+                .clientKeyPemFile(vaultTestContainer.getClientCertificateFiles().clientKeyFile().toFile())
+                .verify(true)
+                .build();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        if (vaultTestContainer != null) {
+            vaultTestContainer.stop();
+        }
+    }
+
+    /**
+     * Verify that Vault rejects the TLS handshake when a client certificate signed by a different CA
+     * is presented. The server requires mutual TLS and the client cert CA is not in {@code tls_client_ca_file}.
+     */
+    @Test
+    public void testMutualTlsRejectsUntrustedClientCert() throws Exception {
+        Path wrongCertDir = Files.createTempDirectory("wrong_mtls_certs");
+        try {
+            CertificateRequest request = new CertificateRequest()
+                    .withName("wrong")
+                    .withPassword("secret")
+                    .withClientCertificate()
+                    .withFormat(Format.PEM);
+            List<CertificateFiles> wrongCerts = new CertificateGenerator(wrongCertDir, true).generate(request);
+            PemCertificateFiles wrongPem = (PemCertificateFiles) wrongCerts.stream()
+                    .filter(f -> f instanceof PemCertificateFiles).findFirst().get();
+
+            SslConfig wrongClientConfig = new SslConfig()
+                    .pemFile(vaultTestContainer.getHttpsTrustFile().toFile())
+                    .clientPemFile(wrongPem.clientCertFile().toFile())
+                    .clientKeyPemFile(wrongPem.clientKeyFile().toFile())
+                    .verify(true)
+                    .build();
+
+            VaultConnector connector = new VaultConnector(
+                    vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", wrongClientConfig, true);
+            assertThrows(VaultException.class, connector::configure);
+        } finally {
+            VaultTestUtils.cleanupDir(wrongCertDir);
+        }
+    }
+
+    /**
+     * Verify that Vault rejects the TLS handshake when no client certificate is presented
+     * and mutual TLS is required.
+     */
+    @Test
+    public void testMutualTlsRejectsNoClientCert() throws Exception {
+        SslConfig trustOnlyConfig = new SslConfig()
+                .pemFile(vaultTestContainer.getHttpsTrustFile().toFile())
+                .verify(true)
+                .build();
+
+        VaultConnector connector = new VaultConnector(
+                vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", trustOnlyConfig, true);
+        assertThrows(VaultException.class, connector::configure);
+    }
+
+    /**
+     * Verify that Vault rejects the TLS handshake when an untrusted client certificate is presented
+     * via a custom {@link SSLContext} / {@link java.net.http.HttpClient} code path.
+     */
+    @Test
+    public void testMutualTlsRejectsUntrustedClientCertViaHttpClient() throws Exception {
+        Path wrongCertDir = Files.createTempDirectory("wrong_mtls_httpclient_certs");
+        try {
+            CertificateRequest request = new CertificateRequest()
+                    .withName("wrong")
+                    .withPassword("secret")
+                    .withClientCertificate()
+                    .withFormat(Format.PEM);
+            List<CertificateFiles> wrongCerts = new CertificateGenerator(wrongCertDir, true).generate(request);
+            PemCertificateFiles wrongPem = (PemCertificateFiles) wrongCerts.stream()
+                    .filter(f -> f instanceof PemCertificateFiles).findFirst().get();
+
+            SSLContext wrongSslContext = SslContextTestHelper.createWithClientAuth(
+                    vaultTestContainer.getHttpsTrustFile(),
+                    wrongPem.clientCertFile(),
+                    wrongPem.clientKeyFile());
+
+            SslConfig sslConfig = new SslConfig().verify(true).build();
+            VaultConnector connector = new VaultConnector(
+                    vaultTestContainer.composeHttpsHostAddress(), "", null, sslConfig, true, wrongSslContext);
+            assertThrows(VaultException.class, connector::configure);
+        } finally {
+            VaultTestUtils.cleanupDir(wrongCertDir);
+        }
+    }
+}

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
@@ -6,6 +6,11 @@ package org.wildfly.security.hashicorp.vault;
 
 import io.github.jopenlibs.vault.SslConfig;
 import io.github.jopenlibs.vault.VaultException;
+import io.smallrye.certs.CertificateFiles;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.PemCertificateFiles;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +19,9 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.wildfly.security.hashicorp.vault.auth.TlsCertAuthConfig;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -107,4 +115,53 @@ public class VaultConnectorTlsAuthTestCase {
         assertNull(vaultService.getSecret("secret/testing1", "top_secret"));
     }
 
+    /**
+     * Verify that cert auth login fails when a client certificate signed by a different CA is presented.
+     * The TLS handshake succeeds (tls_require_and_verify_client_cert is false) but loginByCert() fails
+     * because the certificate is not registered in Vault's cert auth backend.
+     */
+    @Test
+    public void testCertAuthFailsWithUntrustedClientCert() throws Exception {
+        Path wrongCertDir = Files.createTempDirectory("wrong_client_certs");
+        try {
+            CertificateRequest request = new CertificateRequest()
+                    .withName("wrong")
+                    .withPassword("secret")
+                    .withClientCertificate()
+                    .withFormat(Format.PEM);
+            List<CertificateFiles> wrongCerts = new CertificateGenerator(wrongCertDir, true).generate(request);
+            PemCertificateFiles wrongPem = (PemCertificateFiles) wrongCerts.stream()
+                    .filter(f -> f instanceof PemCertificateFiles).findFirst().get();
+
+            SslConfig wrongClientConfig = new SslConfig()
+                    .pemFile(vaultTestContainer.getHttpsTrustFile().toFile())
+                    .clientPemFile(wrongPem.clientCertFile().toFile())
+                    .clientKeyPemFile(wrongPem.clientKeyFile().toFile())
+                    .verify(true)
+                    .build();
+
+            VaultConnector vaultService = new VaultConnector(
+                    vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", wrongClientConfig, true);
+            assertThrows(VaultException.class, vaultService::configure);
+        } finally {
+            VaultTestUtils.cleanupDir(wrongCertDir);
+        }
+    }
+
+    /**
+     * Verify that cert auth login fails when no client certificate is presented.
+     * The TLS handshake succeeds (tls_require_and_verify_client_cert is false) but
+     * ClientCertificateLoginStrategy fails because there is no certificate to authenticate with.
+     */
+    @Test
+    public void testCertAuthFailsWithNoClientCert() throws Exception {
+        SslConfig trustOnlyConfig = new SslConfig()
+                .pemFile(vaultTestContainer.getHttpsTrustFile().toFile())
+                .verify(true)
+                .build();
+
+        VaultConnector vaultService = new VaultConnector(
+                vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", trustOnlyConfig, true);
+        assertThrows(VaultException.class, vaultService::configure);
+    }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerHttps.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerHttps.java
@@ -35,13 +35,14 @@ public class VaultContainerHttps<SELF extends VaultContainerHttps<SELF>> extends
 
     private static final Path VAULT_CERT_CONTAINER_PATH = Path.of("/vault/certs");
 
-    private static final String VAULT_CONFIG = String.format(
+    private static String vaultConfig(boolean requireMutualTls) {
+        return String.format(
             "listener \"tcp\" {\n" +
             "  address             = \"0.0.0.0:%d\"\n" +
             "  tls_cert_file       = \"%s\"\n" +
             "  tls_key_file        = \"%s\"\n" +
             "  tls_client_ca_file  = \"%s\"\n" +
-            "  tls_require_and_verify_client_cert = false\n" +
+            "  tls_require_and_verify_client_cert = %s\n" +
             "}\n" +
             "\n" +
             "storage \"file\" {\n" +
@@ -56,8 +57,10 @@ public class VaultContainerHttps<SELF extends VaultContainerHttps<SELF>> extends
             VAULT_CERT_CONTAINER_PATH.resolve(VAULT_CERT_NAME).toAbsolutePath(),
             VAULT_CERT_CONTAINER_PATH.resolve(VAULT_CERT_KEY_NAME).toAbsolutePath(),
             VAULT_CERT_CONTAINER_PATH.resolve(CLIENT_CA_CERT_NAME).toAbsolutePath(),
+            requireMutualTls,
             HTTPS_PORT
-    );
+        );
+    }
 
     //custom admin policy configuration - grants all rights the root policy has
     private static final String ADMIN_POLICY_CONFIG = "path \"*\" {\n" +
@@ -81,7 +84,24 @@ public class VaultContainerHttps<SELF extends VaultContainerHttps<SELF>> extends
     private final Path mountedVaultCertsDir;
     private final Path mountedVaultConfigDir;
 
+    /**
+     * Create a Vault container with HTTPS enabled on port 8400. Client certificate is not required.
+     */
     public VaultContainerHttps(String dockerImageName) throws IOException {
+        this(dockerImageName, false);
+    }
+
+    /**
+     * Create a Vault container with HTTPS enabled on port 8400.
+     *
+     * @param requireMutualTls when {@code true}, Vault sets {@code tls_require_and_verify_client_cert = true}
+     *        and rejects TLS connections that do not present a valid client certificate.
+     *        When {@code false}, client certificates are optional -- connections without a client cert
+     *        are accepted at the TLS level, but cert-based authentication may still fail at the Vault auth level.
+     *        Health check uses the HTTP dev port (8200) when mutual TLS is required, since the HTTPS port
+     *        would reject the health probe.
+     */
+    public VaultContainerHttps(String dockerImageName, boolean requireMutualTls) throws IOException {
         super(dockerImageName);
 
         final MountableFile certs;
@@ -97,7 +117,7 @@ public class VaultContainerHttps<SELF extends VaultContainerHttps<SELF>> extends
             prepareCertificatesForHttps(this.generatedCertificatesDir, this.mountedVaultCertsDir);
             certs = MountableFile.forHostPath(this.mountedVaultCertsDir, 0777);
 
-            config = MountableFile.forHostPath(prepareVaultConfig(this.mountedVaultConfigDir), 0777);
+            config = MountableFile.forHostPath(prepareVaultConfig(this.mountedVaultConfigDir, requireMutualTls), 0777);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -109,10 +129,16 @@ public class VaultContainerHttps<SELF extends VaultContainerHttps<SELF>> extends
                 .withInitCommand("policy write admin " + VAULT_CONFIG_CONTAINER_PATH.resolve(ADMIN_POLICY_CONFIG_NAME).toAbsolutePath())
                 .withCommand("server", "-dev");
 
-        this.setWaitStrategy(Wait.forHttps("/v1/sys/health")
-                .forPort(HTTPS_PORT)
-                .allowInsecure()
-                .forResponsePredicate(response -> response.contains("\"initialized\":true")));
+        if (requireMutualTls) {
+            this.setWaitStrategy(Wait.forHttp("/v1/sys/health")
+                    .forPort(8200)
+                    .forResponsePredicate(response -> response.contains("\"initialized\":true")));
+        } else {
+            this.setWaitStrategy(Wait.forHttps("/v1/sys/health")
+                    .forPort(HTTPS_PORT)
+                    .allowInsecure()
+                    .forResponsePredicate(response -> response.contains("\"initialized\":true")));
+        }
     }
 
     private static void prepareCertificatesForHttps(final Path certTmpDir, final Path vaultTmpCertDir) throws Exception {
@@ -162,10 +188,10 @@ public class VaultContainerHttps<SELF extends VaultContainerHttps<SELF>> extends
      * Write configuration strings to files
      * @param vaultConfigDir where to copy hcl configuration files
      */
-    private static Path prepareVaultConfig(final Path vaultConfigDir) throws IOException {
+    private static Path prepareVaultConfig(final Path vaultConfigDir, boolean requireMutualTls) throws IOException {
         final Path vaultConfigFile = vaultConfigDir.resolve(VAULT_CONFIG_NAME);
         final Path adminPolicyConfigFile = vaultConfigDir.resolve(ADMIN_POLICY_CONFIG_NAME);
-        Files.writeString(vaultConfigFile, VAULT_CONFIG);
+        Files.writeString(vaultConfigFile, vaultConfig(requireMutualTls));
         Files.writeString(adminPolicyConfigFile, ADMIN_POLICY_CONFIG);
         return vaultConfigDir;
     }


### PR DESCRIPTION
### Summary

  - Add 7 negative TLS tests covering server trust failures, client cert auth failures, and mutual TLS handshake rejection
  - Extend VaultContainerHttps with requireMutualTls parameter to support testing TLS handshake-level rejection
  - Tests verify that invalid/missing certificates are properly rejected at both the Vault auth level and the TLS handshake level

### Changes

  VaultContainerHttps -- Added boolean requireMutualTls constructor parameter. When true, Vault config sets tls_require_and_verify_client_cert = true and health check uses the HTTP dev port
  (8200) since the HTTPS port would reject the probe without a client cert.

  VaultConnectorHttpsTestCase -- 2 new negative tests:
  - testConnectionFailsWithUntrustedServerCert() -- client trusts a different CA
  - testConnectionFailsWithNoTrustConfigured() -- no trust PEM provided

  VaultConnectorTlsAuthTestCase -- 2 new negative tests (auth-level rejection, tls_require_and_verify_client_cert = false):
  - testCertAuthFailsWithUntrustedClientCert() -- wrong client cert, loginByCert() fails
  - testCertAuthFailsWithNoClientCert() -- no client cert, ClientCertificateLoginStrategy fails

  VaultConnectorMutualTlsTestCase (new) -- 3 negative tests (handshake-level rejection, tls_require_and_verify_client_cert = true):
  - testMutualTlsRejectsUntrustedClientCert() -- wrong client cert CA
  - testMutualTlsRejectsNoClientCert() -- no client cert presented 
  - testMutualTlsRejectsUntrustedClientCertViaHttpClient() -- wrong cert via SSLContext/HttpClient code path
