### PR TITLE
Allow cert auth without token, add credential store TLS auth tests

### DIFF
--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -100,10 +100,13 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         try {
             char[] password = getStorePassword(protectionParameter);
             String token = password != null ? String.valueOf(password) : null;
-            if (token == null) {
-                throw ROOT_LOGGER.vaultTokenRequired();
+            boolean hasToken = token != null && !token.trim().isEmpty();
+            boolean hasClientCertConfig = this.sslContext != null
+                    || (this.keyStorePath != null && !this.keyStorePath.trim().isEmpty());
+            if (!hasToken && !hasClientCertConfig) {
+                throw ROOT_LOGGER.noAuthenticationMethodConfigured();
             }
-            
+
             SslConfig sslConfig = new SslConfig().verify(true);
             
             if (this.keyStorePath != null && !this.keyStorePath.trim().isEmpty()) {

--- a/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
@@ -36,8 +36,8 @@ public interface HashiCorpVaultLogger extends BasicLogger {
     @Message(id = 2, value = "host-address attribute is required")
     CredentialStoreException hostAddressRequired();
 
-    @Message(id = 3, value = "No authentication method configured: provide either a vault token (via credential-reference) or TLS client certificate authentication (via authentication-context)")
-    CredentialStoreException noAuthenticationMethodConfigured();
+    @Message(id = 3, value = "Vault token is required")
+    CredentialStoreException vaultTokenRequired();
 
     @Message(id = 4, value = "Failed to load KeyStore from path: %s")
     CredentialStoreException failedToLoadKeyStore(String detail, @Cause Exception e);
@@ -224,4 +224,7 @@ public interface HashiCorpVaultLogger extends BasicLogger {
 
     @Message(id = 59, value = "Unexpected test container output type %s")
     IllegalArgumentException unexpectedTestContainerOutputType(Object outputType);
+
+    @Message(id = 60, value = "No authentication method configured: provide either a vault token (via credential-reference) or TLS client certificate authentication (via authentication-context)")
+    CredentialStoreException noAuthenticationMethodConfigured();
 }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
@@ -36,8 +36,8 @@ public interface HashiCorpVaultLogger extends BasicLogger {
     @Message(id = 2, value = "host-address attribute is required")
     CredentialStoreException hostAddressRequired();
 
-    @Message(id = 3, value = "Vault token is required")
-    CredentialStoreException vaultTokenRequired();
+    @Message(id = 3, value = "No authentication method configured: provide either a vault token (via credential-reference) or TLS client certificate authentication (via authentication-context)")
+    CredentialStoreException noAuthenticationMethodConfigured();
 
     @Message(id = 4, value = "Failed to load KeyStore from path: %s")
     CredentialStoreException failedToLoadKeyStore(String detail, @Cause Exception e);

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
@@ -638,8 +638,10 @@ public class HashicorpVaultCredentialStoreTestCase {
     }
 
     /**
-     * Call {@code initialize()} with {@code null} protection parameter (no token provided).
-     * Test passes when {@link CredentialStoreException} is thrown indicating token is required.
+     * Call {@code initialize()} with {@code null} protection parameter (no token provided) and no
+     * alternative auth method configured. The null token passes through to
+     * {@code VaultConnector.tryLoginWithFallback()} which fails because no login strategy succeeds.
+     * Test passes when {@link CredentialStoreException} is thrown.
      */
     @Test
     public void testInitializeWithNullProtectionParameter() {

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
@@ -639,9 +639,9 @@ public class HashicorpVaultCredentialStoreTestCase {
 
     /**
      * Call {@code initialize()} with {@code null} protection parameter (no token provided) and no
-     * alternative auth method configured. The null token passes through to
-     * {@code VaultConnector.tryLoginWithFallback()} which fails because no login strategy succeeds.
-     * Test passes when {@link CredentialStoreException} is thrown.
+     * alternative auth method configured (no SSLContext or key-store-path).
+     * Test passes when {@link CredentialStoreException} is thrown by the early validation
+     * in {@code HashicorpVaultCredentialStore} indicating that no authentication method is configured.
      */
     @Test
     public void testInitializeWithNullProtectionParameter() {

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTlsAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTlsAuthTestCase.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import io.smallrye.certs.CertificateFiles;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.PemCertificateFiles;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.wildfly.security.auth.server.IdentityCredentials;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.store.CredentialStore;
+import org.wildfly.security.credential.store.CredentialStoreException;
+import org.wildfly.security.hashicorp.vault.auth.TlsCertAuthConfig;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+import javax.net.ssl.SSLContext;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.Provider;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests that {@link HashicorpVaultCredentialStore} works with TLS certificate authentication,
+ * allowing initialization without a Vault token when a client certificate is configured.
+ */
+public class HashicorpVaultCredentialStoreTlsAuthTestCase {
+
+    private VaultContainerHttps<?> vaultTestContainer;
+    private SSLContext sslContext;
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        vaultTestContainer = new VaultContainerHttps<>("hashicorp/vault:1.13")
+                .withVaultToken("myroot")
+                .withInitCommand(
+                        "secrets enable transit",
+                        "write -f transit/keys/my-key",
+                        "kv put secret/testing1 ttl=30m top_secret=password123",
+                        "kv put secret/testing2 ttl=30m dbuser=secretpass jmsuser=jmspass"
+                );
+
+        new TlsCertAuthConfig.Builder(vaultTestContainer.getClientCertificateFiles())
+                .policies("admin")
+                .build()
+                .configure(vaultTestContainer);
+
+        vaultTestContainer.start();
+
+        sslContext = SslContextTestHelper.createWithClientAuth(
+                vaultTestContainer.getHttpsTrustFile(),
+                vaultTestContainer.getClientCertificateFiles().clientCertFile(),
+                vaultTestContainer.getClientCertificateFiles().clientKeyFile());
+    }
+
+    @AfterEach
+    public void cleanup() {
+        if (vaultTestContainer != null) {
+            vaultTestContainer.stop();
+        }
+    }
+
+    /**
+     * Initialize credential store with {@code null} protection parameter (no token).
+     * Cert auth via the SSLContext should succeed and allow secret retrieval.
+     */
+    @Test
+    public void testCertAuthWithNullProtectionParameter() throws Exception {
+        HashicorpVaultCredentialStore store = createStoreWithCertAuth(null);
+        PasswordCredential credential = store.retrieve("secret/testing1.top_secret",
+                PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, null);
+        assertNotNull(credential);
+        assertEquals("password123", String.valueOf(credential.getPassword(ClearPassword.class).getPassword()));
+    }
+
+    /**
+     * Initialize credential store with a whitespace token. The connector skips token auth
+     * and falls back to cert auth.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"  ", "\t", "\n"})
+    public void testCertAuthWithWhitespaceToken(String token) throws Exception {
+        HashicorpVaultCredentialStore store = createStoreWithCertAuth(
+                createProtectionParameter(token));
+        PasswordCredential credential = store.retrieve("secret/testing1.top_secret",
+                PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, null);
+        assertNotNull(credential);
+        assertEquals("password123", String.valueOf(credential.getPassword(ClearPassword.class).getPassword()));
+    }
+
+    /**
+     * Full CRUD cycle using cert auth with no token: store a secret, retrieve it,
+     * remove it, and verify it is gone.
+     */
+    @Test
+    public void testCertAuthCrudOperations() throws Exception {
+        HashicorpVaultCredentialStore store = createStoreWithCertAuth(null);
+
+        PasswordCredential credential = createCredentialFromPassword("mySecretValue");
+        store.store("secret/certtest.password", credential, null);
+
+        PasswordCredential retrieved = store.retrieve("secret/certtest.password",
+                PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, null);
+        assertNotNull(retrieved);
+        assertEquals("mySecretValue", String.valueOf(retrieved.getPassword(ClearPassword.class).getPassword()));
+
+        store.remove("secret/certtest.password", PasswordCredential.class,
+                ClearPassword.ALGORITHM_CLEAR, null);
+
+        PasswordCredential afterRemove = store.retrieve("secret/certtest.password",
+                PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, null);
+        assertNull(afterRemove);
+    }
+
+    /**
+     * Cert auth fails when a client certificate signed by a different CA is presented.
+     * TLS handshake succeeds but Vault's cert auth rejects the unregistered certificate.
+     */
+    @Test
+    public void testCertAuthFailsWithUntrustedClientCert() throws Exception {
+        Path wrongCertDir = Files.createTempDirectory("wrong_client_certs");
+        try {
+            CertificateRequest request = new CertificateRequest()
+                    .withName("wrong")
+                    .withPassword("secret")
+                    .withClientCertificate()
+                    .withFormat(Format.PEM);
+            List<CertificateFiles> wrongCerts = new CertificateGenerator(wrongCertDir, true).generate(request);
+            PemCertificateFiles wrongPem = (PemCertificateFiles) wrongCerts.stream()
+                    .filter(f -> f instanceof PemCertificateFiles).findFirst().get();
+
+            SSLContext wrongSslContext = SslContextTestHelper.createWithClientAuth(
+                    vaultTestContainer.getHttpsTrustFile(),
+                    wrongPem.clientCertFile(),
+                    wrongPem.clientKeyFile());
+
+            HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
+            store.setSslContext(wrongSslContext);
+            Map<String, String> attributes = new HashMap<>();
+            attributes.put("host-address", vaultTestContainer.composeHttpsHostAddress());
+            assertThrows(CredentialStoreException.class,
+                    () -> store.initialize(attributes, null,
+                            new Provider[]{WildFlyElytronPasswordProvider.getInstance()}));
+        } finally {
+            VaultTestUtils.cleanupDir(wrongCertDir);
+        }
+    }
+
+    /**
+     * Cert auth fails when no client certificate is presented.
+     * The SSLContext has trust only (no client key/cert), so ClientCertificateLoginStrategy fails.
+     */
+    @Test
+    public void testCertAuthFailsWithNoClientCert() throws Exception {
+        SSLContext trustOnlyContext = SslContextTestHelper.createTrustOnly(
+                vaultTestContainer.getHttpsTrustFile());
+
+        HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
+        store.setSslContext(trustOnlyContext);
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("host-address", vaultTestContainer.composeHttpsHostAddress());
+        assertThrows(CredentialStoreException.class,
+                () -> store.initialize(attributes, null,
+                        new Provider[]{WildFlyElytronPasswordProvider.getInstance()}));
+    }
+
+    private HashicorpVaultCredentialStore createStoreWithCertAuth(
+            CredentialStore.ProtectionParameter protectionParameter) throws Exception {
+        HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
+        store.setSslContext(sslContext);
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("host-address", vaultTestContainer.composeHttpsHostAddress());
+        store.initialize(attributes, protectionParameter,
+                new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
+        return store;
+    }
+
+    private static CredentialStore.CredentialSourceProtectionParameter createProtectionParameter(
+            String password) throws Exception {
+        return new CredentialStore.CredentialSourceProtectionParameter(
+                IdentityCredentials.NONE.withCredential(createCredentialFromPassword(password)));
+    }
+
+    private static PasswordCredential createCredentialFromPassword(String password) throws Exception {
+        PasswordFactory factory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR,
+                WildFlyElytronPasswordProvider.getInstance());
+        return new PasswordCredential(factory.generatePassword(
+                new ClearPasswordSpec(password.toCharArray())));
+    }
+}


### PR DESCRIPTION
Remove the premature null token check in HashicorpVaultCredentialStore that prevented TLS certificate authentication from working without a credential-reference. The VaultConnector already handles null/blank tokens by falling back to ClientCertificateLoginStrategy.

Replace the check with an early validation that fails only when neither a token nor a client certificate configuration is available, with a clear error message guiding the user.

Add HashicorpVaultCredentialStoreTlsAuthTestCase with 5 test scenarios covering cert auth with null token, whitespace tokens, full CRUD, untrusted cert, and missing cert.