### PR TITLE
Issue #68 / Issue #70 Adoption of a new alias format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A credential store implementation for WildFly that integrates with HashiCorp Vau
 ## Requirements
 
 - HashiCorp Vault server
-- WildFly server 
+- WildFly server
 - Java
 - Maven
 - Vault Java driver
@@ -51,13 +51,13 @@ To test with specific Java versions (17, 21, or 25), you need to set up Maven to
    ```bash
    # Test with Java 17
    mvn clean test -Djdk.test.version=17
-   
+
    # Test with Java 21
    mvn clean test -Djdk.test.version=21
-   
+
    # Test with Java 25 (default)
    mvn clean test -Djdk.test.version=25
-   
+
    # Test with specific distribution
    mvn clean test -Djdk.test.version=21 -Djdk.test.vendor=semeru
    ```
@@ -95,7 +95,7 @@ Example result configuration (`standalone.xml` or `domain.xml`):
 <subsystem xmlns="urn:wildfly:elytron:15.0">
     ...
     <credential-stores>
-        <credential-store name="vault-store" 
+        <credential-store name="vault-store"
                          type="HashicorpVaultCredentialStore"
                          providers="vaultProviderLoader">
             <implementation-properties>
@@ -113,11 +113,36 @@ Example result configuration (`standalone.xml` or `domain.xml`):
 
 ### 2. Use the Credential Store
 
-**Note:** The alias format is: `<vault-path>.<key>`
+Reference credentials from Vault in your WildFly configuration using the alias format.
 
-```bash
-/subsystem=elytron/credential-store=vault-store:add-alias(alias="/secrets/test.db_user", secret-value="db_user_pass")
+#### Alias Format
+
+The credential store supports a structured alias format for referencing secrets:
+
 ```
+[engine=TYPE][@mount-path][#]secret-path?key-path
+```
+
+**Simple examples:**
+```
+myapp/database?password              # Simple key
+myapp/config?database/host           # Nested JSON path
+services?my.app/config.key           # Nested with dots in keys
+```
+
+**Advanced examples:**
+```
+engine=KVv1#old-app/config?api_key   # Specify engine type
+@prod/secrets#myapp/db?password      # Custom mount path
+```
+
+For complete alias format documentation, see [`docs/alias-format.md`](docs/alias-format.md).
+
+#### Legacy Format Support
+
+The legacy format (`secret-path.key`) is supported for backward compatibility when `support-legacy-alias-format` is enabled. See [`docs/migration.md`](docs/migration.md) for migration guidance.
+
+#### Using Credentials
 
 Reference credentials from Vault in your WildFly configuration:
 
@@ -130,7 +155,7 @@ Reference credentials from Vault in your WildFly configuration:
             <driver>postgresql</driver>
             <security>
                 <user-name>dbuser</user-name>
-                <credential-reference store="vault-store" alias="secret/myapp.database_password"/>
+                <credential-reference store="vault-store" alias="myapp/database?password"/>
             </security>
         </datasource>
     </datasources>
@@ -148,7 +173,7 @@ Reference credentials from Vault in your WildFly configuration:
     </security-realms>
     <dir-contexts>
         <dir-context name="ldap-connection" url="ldap://ldap.example.com:389">
-            <credential-reference store="vault-store" alias="secret/ldap.bind_password"/>
+            <credential-reference store="vault-store" alias="ldap/config?bind_password"/>
         </dir-context>
     </dir-contexts>
 </subsystem>
@@ -163,6 +188,19 @@ Reference credentials from Vault in your WildFly configuration:
 | `trustStorePath` | No | Path to trust store for SSL | `/path/to/truststore.jks` |
 | `keyStorePath` | No | Path to key store for client auth | `/path/to/keystore.jks` |
 | `keyStorePass` | No | Key store password | `keystore-password` |
+| `support-legacy-alias-format` | No | Enable legacy format support | `true` or `false` |
+| `default-engine-type` | No | Default secret engine type | `KVv2` (default), `KVv1`, etc. |
+| `default-mount-path` | No | Default mount path | `secret` (default) |
+
+## Documentation
+
+Comprehensive documentation is available in the [`docs/`](docs/) directory:
+
+- **[Alias Format Specification](docs/alias-format.md)** - Complete guide to the alias format syntax, examples, and best practices
+- **[Configuration Guide](docs/configuration.md)** - Detailed configuration parameters and examples
+- **[Migration Guide](docs/migration.md)** - Step-by-step guide for migrating from legacy format
+
+For complete configuration documentation, see [`docs/configuration.md`](docs/configuration.md).
 
 ## Quickstart example
 

--- a/docs/alias-format.md
+++ b/docs/alias-format.md
@@ -1,0 +1,381 @@
+# Vault Alias Format Specification
+
+## Overview
+
+The WildFly Elytron HashiCorp Vault credential store uses a structured alias format to reference secrets stored in HashiCorp Vault. This format supports multiple secret engines, custom mount paths, nested JSON traversal, and maintains backward compatibility with the legacy format.
+
+## Syntax
+
+```
+[engine=TYPE][@mount-path][#]secret-path?key-path
+```
+
+### Components
+
+- **`engine=TYPE`** (optional) - Specifies the Vault secret engine type
+- **`@mount-path`** (optional) - Specifies a custom mount path
+- **`#`** (optional/required) - Secret path marker (see rules below)
+- **`secret-path`** (required) - Path to the secret in Vault
+- **`?`** (required) - Key path delimiter
+- **`key-path`** (required) - Path to the specific value within the secret
+
+### Rules for `#` Delimiter
+
+- **Optional** when alias starts with secret path: `myapp/database?password`
+- **Required** when `engine=` is present: `engine=KVv1#secret?key`
+- **Required** when `@` is present: `@custom#secret?key`
+
+### Defaults
+
+- **Engine:** `KVv2` (if `engine=` omitted)
+- **Mount:** `secret` (if `@` omitted)
+- **Key:** REQUIRED (no default)
+
+## Delimiters Explained
+
+### `engine=` - Engine Type Prefix
+Specifies the Vault secret engine type. Supported values:
+- `KVv2` - Key-Value version 2 (default, recommended)
+- `KVv1` - Key-Value version 1 (for legacy Vault configurations)
+
+### `@` - Mount Path Delimiter
+Indicates a custom mount path. The mount path follows the `@` and ends at the `#`.
+
+### `#` - Secret Path Marker
+Separates the mount path from the secret path. Required when using `engine=` or `@` prefixes.
+
+### `?` - Key Path Delimiter
+Separates the secret path from the key path. Always required.
+
+### `/` - JSON Path Traversal
+Within the key path, `/` indicates nested JSON traversal.
+
+## Key Path Syntax
+
+Key paths support two modes:
+
+### 1. Simple Key (Literal Match)
+Use when the JSON key itself contains dots:
+```
+?db.host          → Look for key literally named "db.host"
+?my.app.config    → Look for key literally named "my.app.config"
+```
+
+### 2. Nested Path (JSON Traversal)
+Use `/` to traverse nested JSON objects:
+```
+?database/host    → Traverse: data["database"]["host"]
+?app/config/key   → Traverse: data["app"]["config"]["key"]
+```
+
+### 3. Nested with Dots in Keys
+Combine both approaches:
+```
+?my.app/config.key    → Traverse: data["my.app"]["config.key"]
+?config/db.host       → Traverse: data["config"]["db.host"]
+```
+
+## Examples
+
+### Simple Keys (Top-Level)
+
+```
+# Minimal format (# is optional)
+myapp/database?password
+
+# Key with dots (literal match)
+myapp/database?db.host
+
+# With # (also valid)
+#myapp/config?api_key
+
+# Key with multiple dots
+services?my.app.config.value
+
+# URL-encoded space in secret path
+test%20path?password
+```
+
+### Nested JSON Paths
+
+Given Vault secret: `{"database": {"host": "localhost", "port": 5432}}`
+
+```
+myapp/config?database/host     → "localhost"
+myapp/config?database/port     → "5432"
+```
+
+Given Vault secret: `{"app": {"prod": {"key": "secret"}}}`
+
+```
+services?app/prod/key          → "secret"
+```
+
+### Mixed: Nested Path with Dots in Keys
+
+Given Vault secret: `{"team": {"my.app": {"key": "value"}}}`
+
+```
+services?team/my.app/key       → "value"
+# The dot in "my.app" is part of the key name, not a path separator
+```
+
+Given Vault secret: `{"db.config": {"host": "localhost"}}`
+
+```
+myapp?db.config/host           → "localhost"
+# "db.config" is a literal key name, "/" traverses into it
+```
+
+### Real-World Examples
+
+```
+# Simple format (most common - no # needed)
+myapp/database?password
+myapp/config?database/connection/password
+services/auth?jwt/signing/key
+
+# With explicit engine type (# required)
+engine=KVv2#myapp/database?password
+engine=KVv1#old-app/config?api.key.v2
+
+# With custom mount (# required)
+@prod/vault#myapp/database?password
+@team/backend#services/auth?jwt/signing/key
+
+# Everything explicit
+engine=KVv2@company/prod#division/team?app.config/db.settings/password
+
+# URL-encoded characters in paths
+test%20path?password                    # Space in path
+test%23path?key                         # # in path
+@mount%2Fname#secret%20path?db.host     # Multiple encoded chars
+```
+
+### Edge Cases
+
+```
+# If user has # in mount name (URL-encode it):
+@test%23mount#secret?key
+
+# If user has # in secret path without prefix (# becomes required):
+#secret%23path?key
+
+# If user has ? in secret path (URL-encode it):
+secret%3Fpath?key
+
+# URL-encoded characters work naturally:
+path%20with%20spaces?password
+path%2Fwith%2Fslash?key
+```
+
+## URL Encoding
+
+### When to URL-Encode
+
+You **MUST** URL-encode the following characters in mount paths and secret paths:
+
+| Character | Encoding | When Required |
+|-----------|----------|---------------|
+| `#` | `%23` | Always in paths |
+| `?` | `%3F` | Always in paths (rare) |
+| Space | `%20` | Always |
+| `/` | `%2F` | When `/` is part of path segment name (rare) |
+
+### URL Encoding Examples
+
+```bash
+# Creating secrets in Vault with special characters:
+vault kv put secret/test%23path key=value    # # encoded as %23
+vault kv put secret/test%3Fpath key=value    # ? encoded as %3F
+vault kv put secret/test%20path key=value    # space encoded as %20
+```
+
+```
+# Using the same encoding in aliases:
+#test%23path?key
+#test%3Fpath?key
+#test%20path?password
+```
+
+### Important: Decode After Splitting
+
+The implementation decodes URL-encoded segments **after** splitting on delimiters. This prevents double-encoding issues:
+
+```
+User provides:  #test%20path?key
+Split on ?:     secret="test%20path", key="key"
+Decode each:    secret="test path", key="key"
+Pass to Vault:  "test path"
+Vault client:   Encodes to "test%20path" ✓ CORRECT
+```
+
+## Key Path Resolution Algorithm
+
+The key path resolution follows these rules:
+
+1. **No `/` in key path** → Direct lookup (supports dots in key name)
+   ```
+   keyPath = "db.host"
+   → data.get("db.host")
+   ```
+
+2. **Contains `/`** → Split on `/` and traverse
+   ```
+   keyPath = "database/host"
+   → data.get("database").get("host")
+   ```
+
+3. **Nested with dots** → Each segment can contain dots
+   ```
+   keyPath = "my.app/config.key"
+   → data.get("my.app").get("config.key")
+   ```
+
+### Resolution Examples
+
+Given Vault secret data:
+```json
+{
+    "password": "secret123",
+    "db.host": "localhost",
+    "database": {
+        "host": "prod.db.com",
+        "port": 5432,
+        "credentials": {
+            "user": "admin",
+            "pass": "secret"
+        }
+    },
+    "my.app": {
+        "config.key": "value123"
+    }
+}
+```
+
+Key path resolutions:
+```
+?password                    → "secret123"
+?db.host                     → "localhost"
+?database/host               → "prod.db.com"
+?database/port               → "5432"
+?database/credentials/pass   → "secret"
+?my.app/config.key           → "value123"
+```
+
+## Validation Rules
+
+### Required Validations
+
+1. Secret path must not be empty
+2. Key path must not be empty
+3. Engine type must be valid (if specified)
+4. Format must match: `[engine=TYPE][@mount][#]secret?key`
+
+### Key Path Validation
+
+1. **Simple keys:** Any characters except `/` and `?`
+2. **Nested paths:** Segments separated by `/`, each segment can contain dots
+3. **No empty segments:** `database//host` is invalid
+
+## Migration from Legacy Format
+
+### Legacy Format
+
+The legacy format used a dot (`.`) to separate the secret path from the key:
+
+```
+secret-path.key
+```
+
+### Detection Strategy
+
+The implementation automatically detects the format:
+
+- **New format** if alias contains: `?`, `#`, `@`, or starts with `engine=`
+- **Legacy format** if none of the above indicators are present AND the alias contains a dot (`.`)
+
+**Important:** Legacy format support must be explicitly enabled via the `support-legacy-alias-format` configuration parameter. When disabled (default in stable releases), aliases without new format indicators will be rejected with an error message providing the correct new format.
+
+### Migration Examples
+
+| Legacy Format | New Format | Notes |
+|---------------|------------|-------|
+| `myapp/db.password` | `myapp/db?password` | Simple key |
+| `app.config.key` | `app.config?key` | Dots in secret path |
+| `my.app.db.pass` | `my.app.db?pass` | Multiple dots |
+| `app/config.key` | `app?config/key` | Nested key path |
+
+See [migration.md](migration.md) for detailed migration guidance.
+
+## EBNF Grammar
+
+```ebnf
+alias          = [engine-spec] [mount-spec] [hash] secret-spec key-spec
+engine-spec    = "engine=" engine-type
+mount-spec     = "@" mount-path
+hash           = "#"
+secret-spec    = secret-path
+key-spec       = "?" key-path
+
+engine-type    = "KVv1" | "KVv2"
+mount-path     = path-segment *("/" path-segment)
+secret-path    = path-segment *("/" path-segment)
+key-path       = key-segment *("/" key-segment)
+path-segment   = 1*path-char
+key-segment    = 1*key-char
+path-char      = ALPHA / DIGIT / "-" / "_" / "." / ":" / <any char except "#" and "?">
+key-char       = ALPHA / DIGIT / "-" / "_" / "." / ":" / <any char except "/" and "?">
+```
+
+## Advantages
+
+### 1. Handles All Real-World Cases
+- ✅ Paths with dots: `my.app.config?password`
+- ✅ Keys with dots: `?db.host` (literal key name)
+- ✅ Nested JSON: `?database/host` (traverse)
+- ✅ Nested with dots: `?my.app/config.key` (both!)
+- ✅ URL-encoded paths work perfectly
+- ✅ Hierarchical paths: `@team/app#service/db?password`
+- ✅ No restrictions on user naming conventions
+
+### 2. Unambiguous Parsing
+- `?` requires encoding as `%3F` in actual paths → safe delimiter
+- `#` is fragment identifier → safe delimiter
+- `@` is clear "at location" marker
+- `/` in key path means JSON traversal
+- No `/` in key path means literal key lookup
+- No ambiguity with URL-encoded characters
+- Decode-after-split prevents double-encoding
+
+### 3. Flexible Key Resolution
+- Simple keys work naturally (even with dots)
+- Nested paths use intuitive `/` separator
+- Dots in nested keys work automatically
+- No escaping needed for common cases
+
+### 4. Future-Proof
+- Supports any Vault secret engine type
+- Handles arbitrary path complexity
+- Handles arbitrary JSON nesting
+- Extensible format
+
+### 5. Backward Compatible
+- Legacy format still works via detection
+- Gradual migration path
+- No breaking changes required
+
+### 6. User-Friendly
+- No restrictions on dots in paths
+- No restrictions on dots in keys
+- URL-encoded paths work naturally
+- Clear, readable format
+- Single-character delimiters (concise)
+- Minimal encoding requirements (only for rare `#` and `?`)
+- Intuitive nested path syntax
+
+## See Also
+
+- [Configuration Guide](configuration.md) - Credential store configuration parameters
+- [Migration Guide](migration.md) - Migrating from legacy format
+- [WildFly Elytron Documentation](https://docs.wildfly.org/elytron/)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,379 @@
+# Configuration Guide
+
+## Overview
+
+This guide describes all configuration parameters for the WildFly Elytron HashiCorp Vault credential store. The credential store integrates with HashiCorp Vault to securely retrieve credentials for use in WildFly applications.
+
+## Configuration Parameters
+
+### Required Parameters
+
+#### `host-address`
+- **Type:** String (URL)
+- **Required:** Yes
+- **Description:** The base URL of the HashiCorp Vault server
+- **Format:** `protocol://host:port`
+- **Examples:**
+  ```
+  https://vault.example.com:8200
+  http://localhost:8200
+  https://vault.company.internal
+  ```
+
+### Optional Parameters
+
+#### `namespace`
+- **Type:** String
+- **Required:** No
+- **Default:** None (root namespace)
+- **Description:** The Vault namespace to use (Vault Enterprise feature)
+- **Examples:**
+  ```
+  engineering
+  team/backend
+  prod/services
+  ```
+- **Notes:**
+  - Only available in Vault Enterprise
+  - Namespaces provide multi-tenancy within a single Vault instance
+  - Leave unset to use the root namespace
+
+#### `trust-store-path`
+- **Type:** String (file path)
+- **Required:** No
+- **Default:** System default trust store
+- **Description:** Path to a custom trust store for TLS certificate verification
+- **Examples:**
+  ```
+  /etc/pki/trust/vault-ca.jks
+  ${jboss.server.config.dir}/vault-truststore.jks
+  ```
+- **Notes:**
+  - Used when Vault server uses a custom CA certificate
+  - Must be in JKS or PKCS12 format
+  - Requires `trust-store-pass` if the trust store is password-protected
+
+#### `trust-store-pass`
+- **Type:** String (password)
+- **Required:** No (required if `trust-store-path` is set and password-protected)
+- **Default:** None
+- **Description:** Password for the trust store
+- **Security Note:** Consider using credential references or vault expressions for this value
+
+#### `key-store-path`
+- **Type:** String (file path)
+- **Required:** No
+- **Default:** None
+- **Description:** Path to a key store for mutual TLS authentication
+- **Examples:**
+  ```
+  /etc/pki/client/vault-client.jks
+  ${jboss.server.config.dir}/vault-keystore.jks
+  ```
+- **Notes:**
+  - Used when Vault requires client certificate authentication
+  - Must be in JKS or PKCS12 format
+  - Requires `key-store-pass`
+
+#### `key-store-pass`
+- **Type:** String (password)
+- **Required:** No (required if `key-store-path` is set)
+- **Default:** None
+- **Description:** Password for the key store
+- **Security Note:** Consider using credential references or vault expressions for this value
+
+#### `support-legacy-alias-format`
+- **Type:** Boolean
+- **Required:** No
+- **Default:** `false` (legacy format disabled)
+- **Description:** Enable support for the legacy alias format (`secret-path.key`)
+- **Values:**
+  - `true` - Support both new and legacy formats
+  - `false` - Only support new format
+- **Examples:**
+  ```xml
+  <attribute name="support-legacy-alias-format" value="true"/>
+  <attribute name="support-legacy-alias-format" value="false"/>
+  ```
+- **Notes:**
+  - Legacy format: `myapp/database.password`
+  - New format: `myapp/database?password`
+  - See [migration.md](migration.md) for migration guidance
+  - Legacy format will be deprecated in future releases
+
+#### `default-engine-type`
+- **Type:** String (enum)
+- **Required:** No
+- **Default:** `KVv2`
+- **Description:** Default Vault secret engine type when not specified in alias
+- **Valid Values:**
+  - `KVv1` - Key-Value version 1 (for legacy Vault configurations)
+  - `KVv2` - Key-Value version 2 (default, recommended)
+- **Examples:**
+  ```xml
+  <attribute name="default-engine-type" value="KVv2"/>
+  <attribute name="default-engine-type" value="KVv1"/>
+  ```
+- **Notes:**
+  - Can be overridden per-alias using `engine=TYPE` prefix
+  - KVv2 is recommended for most use cases
+
+#### `default-mount-path`
+- **Type:** String
+- **Required:** No
+- **Default:** `secret`
+- **Description:** Default mount path when not specified in alias
+- **Examples:**
+  ```xml
+  <attribute name="default-mount-path" value="secret"/>
+  <attribute name="default-mount-path" value="prod/secrets"/>
+  <attribute name="default-mount-path" value="team/backend"/>
+  ```
+- **Notes:**
+  - Can be overridden per-alias using `@mount-path` prefix
+  - Must match the mount path configured in Vault
+
+## Configuration Examples
+
+### Basic Configuration
+
+Minimal configuration for a local Vault instance:
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="http://localhost:8200"/>
+    </implementation-properties>
+</credential-store>
+```
+
+### Production Configuration with TLS
+
+Configuration with custom CA certificate:
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault.company.com:8200"/>
+        <property name="trust-store-path" value="${jboss.server.config.dir}/vault-ca.jks"/>
+        <property name="trust-store-pass" value="changeit"/>
+    </implementation-properties>
+</credential-store>
+```
+
+### Mutual TLS Configuration
+
+Configuration with client certificate authentication:
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault.company.com:8200"/>
+        <property name="trust-store-path" value="${jboss.server.config.dir}/vault-ca.jks"/>
+        <property name="trust-store-pass" value="changeit"/>
+        <property name="key-store-path" value="${jboss.server.config.dir}/vault-client.jks"/>
+        <property name="key-store-pass" value="clientpass"/>
+    </implementation-properties>
+</credential-store>
+```
+
+### Enterprise Configuration with Namespace
+
+Configuration for Vault Enterprise with namespace:
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault.company.com:8200"/>
+        <property name="namespace" value="engineering/backend"/>
+        <property name="trust-store-path" value="${jboss.server.config.dir}/vault-ca.jks"/>
+        <property name="trust-store-pass" value="changeit"/>
+    </implementation-properties>
+</credential-store>
+```
+
+### Custom Defaults Configuration
+
+Configuration with custom engine type and mount path:
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault.company.com:8200"/>
+        <property name="default-engine-type" value="KVv1"/>
+        <property name="default-mount-path" value="prod/secrets"/>
+        <property name="trust-store-path" value="${jboss.server.config.dir}/vault-ca.jks"/>
+        <property name="trust-store-pass" value="changeit"/>
+    </implementation-properties>
+</credential-store>
+```
+
+### Migration Configuration
+
+Configuration with legacy format support enabled:
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault.company.com:8200"/>
+        <property name="support-legacy-alias-format" value="true"/>
+        <property name="trust-store-path" value="${jboss.server.config.dir}/vault-ca.jks"/>
+        <property name="trust-store-pass" value="changeit"/>
+    </implementation-properties>
+</credential-store>
+```
+
+## Common Configuration Patterns
+
+### Development Environment
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="http://localhost:8200"/>
+        <property name="support-legacy-alias-format" value="true"/>
+    </implementation-properties>
+</credential-store>
+```
+
+**Notes:**
+- Uses HTTP (not recommended for production)
+- No TLS configuration needed
+- Legacy format support for easier migration
+
+### Staging Environment
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault-staging.company.com:8200"/>
+        <property name="default-mount-path" value="staging/secrets"/>
+        <property name="trust-store-path" value="${jboss.server.config.dir}/vault-ca.jks"/>
+        <property name="trust-store-pass" value="changeit"/>
+        <property name="support-legacy-alias-format" value="true"/>
+    </implementation-properties>
+</credential-store>
+```
+
+**Notes:**
+- Uses HTTPS with custom CA
+- Custom mount path for staging secrets
+- Legacy format support during migration period
+
+### Production Environment
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault.company.com:8200"/>
+        <property name="namespace" value="production"/>
+        <property name="default-mount-path" value="prod/secrets"/>
+        <property name="trust-store-path" value="${jboss.server.config.dir}/vault-ca.jks"/>
+        <property name="trust-store-pass" value="${CREDENTIAL_STORE_PASS}"/>
+        <property name="key-store-path" value="${jboss.server.config.dir}/vault-client.jks"/>
+        <property name="key-store-pass" value="${CLIENT_CERT_PASS}"/>
+        <property name="support-legacy-alias-format" value="false"/>
+    </implementation-properties>
+</credential-store>
+```
+
+**Notes:**
+- Uses HTTPS with mutual TLS
+- Vault Enterprise namespace
+- Passwords from environment variables
+- Legacy format disabled (new format only)
+
+## Security Best Practices
+
+### 1. Always Use HTTPS in Production
+```xml
+<property name="host-address" value="https://vault.company.com:8200"/>
+```
+
+### 2. Use Custom CA Certificates
+```xml
+<property name="trust-store-path" value="${jboss.server.config.dir}/vault-ca.jks"/>
+<property name="trust-store-pass" value="changeit"/>
+```
+
+### 3. Consider Mutual TLS for Production
+```xml
+<property name="key-store-path" value="${jboss.server.config.dir}/vault-client.jks"/>
+<property name="key-store-pass" value="clientpass"/>
+```
+
+### 4. Protect Sensitive Configuration Values
+Use environment variables or credential references for passwords:
+```xml
+<property name="trust-store-pass" value="${VAULT_TRUSTSTORE_PASS}"/>
+<property name="key-store-pass" value="${VAULT_KEYSTORE_PASS}"/>
+```
+
+### 5. Use Namespaces for Multi-Tenancy
+```xml
+<property name="namespace" value="team/application"/>
+```
+
+### 6. Disable Legacy Format After Migration
+```xml
+<property name="support-legacy-alias-format" value="false"/>
+```
+
+## Troubleshooting
+
+### Connection Issues
+
+**Problem:** Cannot connect to Vault server
+
+**Solutions:**
+1. Verify `host-address` is correct and accessible
+2. Check network connectivity: `curl https://vault.company.com:8200/v1/sys/health`
+3. Verify TLS certificates if using HTTPS
+4. Check firewall rules
+
+### TLS Certificate Issues
+
+**Problem:** SSL/TLS handshake failures
+
+**Solutions:**
+1. Verify `trust-store-path` points to correct file
+2. Ensure trust store contains Vault server's CA certificate
+3. Check `trust-store-pass` is correct
+4. Verify certificate hasn't expired
+
+### Authentication Issues
+
+**Problem:** Authentication failures
+
+**Solutions:**
+1. Verify Vault token is valid and not expired
+2. Check token has appropriate policies
+3. Verify namespace is correct (if using Vault Enterprise)
+4. Ensure mount path exists in Vault
+
+### Alias Format Issues
+
+**Problem:** Aliases not resolving correctly
+
+**Solutions:**
+1. Check alias format matches specification (see [alias-format.md](alias-format.md))
+2. Verify `default-engine-type` matches your Vault configuration
+3. Verify `default-mount-path` matches your Vault mount
+4. Enable `support-legacy-alias-format` if using old format
+5. Check for URL-encoding issues in paths
+
+## See Also
+
+- [Alias Format Specification](alias-format.md) - Detailed alias format documentation
+- [Migration Guide](migration.md) - Migrating from legacy format
+- [WildFly Elytron Documentation](https://docs.wildfly.org/elytron/)
+- [HashiCorp Vault Documentation](https://www.vaultproject.io/docs)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,604 @@
+# Migration Guide: Legacy to New Alias Format
+
+## Overview
+
+This guide helps you migrate from the legacy alias format to the new structured format. The new format provides better support for nested JSON paths, dots in key names, and multiple secret engines.
+
+## Format Comparison
+
+### Legacy Format
+```
+secret-path.key
+```
+
+The legacy format uses a dot (`.`) to separate the secret path from the key name. This creates ambiguity when paths or keys contain dots.
+
+### New Format
+```
+[engine=TYPE][@mount-path][#]secret-path?key-path
+```
+
+The new format uses explicit delimiters:
+- `?` separates secret path from key path
+- `#` marks the start of the secret path (optional in simple cases)
+- `@` specifies custom mount paths
+- `engine=` specifies the secret engine type
+
+## Why Migrate?
+
+### Problems with Legacy Format
+
+1. **Ambiguous with dots:** `my.app.db.password` - which dot separates path from key?
+2. **No nested JSON support:** Cannot traverse nested JSON structures
+3. **No engine type support:** Assumes KVv2 engine
+4. **No custom mount support:** Assumes `secret` mount
+5. **Limited flexibility:** Cannot handle complex Vault configurations
+
+### Benefits of New Format
+
+1. **Unambiguous parsing:** Clear delimiters for all components
+2. **Nested JSON support:** Use `/` to traverse nested structures
+3. **Dots in keys work naturally:** `?db.host` looks up key literally named "db.host"
+4. **Multiple engine support:** Specify engine type per-alias
+5. **Custom mount paths:** Use different mount paths per-alias
+6. **Future-proof:** Extensible for new Vault features
+
+## Migration Strategy
+
+### Phase 1: Enable Legacy Support (Recommended)
+
+During migration, enable legacy format support to avoid breaking existing configurations:
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault.company.com:8200"/>
+        <property name="support-legacy-alias-format" value="true"/>
+    </implementation-properties>
+</credential-store>
+```
+
+**Note:** The `support-legacy-alias-format` parameter defaults to `false` (legacy format disabled). Set it to `true` to enable legacy format support during migration.
+
+### Phase 2: Convert Aliases
+
+Convert your aliases one at a time, testing each conversion:
+
+#### Simple Conversions
+
+| Legacy Format | New Format | Notes |
+|---------------|------------|-------|
+| `myapp/db.password` | `myapp/db?password` | Simple key |
+| `app.config.key` | `app.config?key` | Dots in secret path |
+| `my.app.db.pass` | `my.app.db?pass` | Multiple dots in path |
+
+#### Nested JSON Conversions
+
+If your Vault secrets contain nested JSON, you can now access nested values:
+
+**Legacy (only top-level keys):**
+```
+myapp/config.database_host
+```
+
+**New (can access nested values):**
+```
+myapp/config?database/host
+```
+
+Given Vault secret:
+```json
+{
+  "database": {
+    "host": "localhost",
+    "port": 5432
+  }
+}
+```
+
+### Phase 3: Test Thoroughly
+
+After converting each alias:
+
+1. **Test retrieval:** Verify the credential is retrieved correctly
+2. **Test application:** Ensure the application works with the new alias
+3. **Check logs:** Look for any warnings or errors
+4. **Document changes:** Keep track of converted aliases
+
+### Phase 4: Disable Legacy Support
+
+Once all aliases are converted and tested:
+
+```xml
+<credential-store name="vault-store"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault.company.com:8200"/>
+        <property name="support-legacy-alias-format" value="false"/>
+    </implementation-properties>
+</credential-store>
+```
+
+## Conversion Examples
+
+### Example 1: Simple Database Password
+
+**Legacy:**
+```
+myapp/database.password
+```
+
+**Vault Secret:**
+```json
+{
+  "password": "secret123",
+  "username": "admin"
+}
+```
+
+**New Format:**
+```
+myapp/database?password
+```
+
+**Explanation:** The `?` clearly separates the secret path (`myapp/database`) from the key (`password`).
+
+### Example 2: Dots in Secret Path
+
+**Legacy:**
+```
+my.app.config.api_key
+```
+
+**Vault Secret Path:** `my.app.config`
+**Key:** `api_key`
+
+**New Format:**
+```
+my.app.config?api_key
+```
+
+**Explanation:** Dots in the secret path work naturally. The `?` delimiter makes it clear where the path ends and the key begins.
+
+### Example 3: Nested JSON Access
+
+**Legacy (couldn't access nested values):**
+```
+myapp/config.database_host
+```
+
+This required flattening the JSON in Vault:
+```json
+{
+  "database_host": "localhost",
+  "database_port": "5432"
+}
+```
+
+**New Format (can access nested values):**
+```
+myapp/config?database/host
+myapp/config?database/port
+```
+
+Now you can use natural JSON structure:
+```json
+{
+  "database": {
+    "host": "localhost",
+    "port": 5432
+  }
+}
+```
+
+### Example 4: Key with Dots
+
+**Legacy:**
+```
+services.db.host
+```
+
+**Ambiguity:** Is the secret path `services.db` with key `host`, or `services` with key `db.host`?
+
+**New Format (secret path: `services`, key: `db.host`):**
+```
+services?db.host
+```
+
+**New Format (secret path: `services.db`, key: `host`):**
+```
+services.db?host
+```
+
+**Explanation:** The `?` delimiter removes all ambiguity.
+
+### Example 5: Nested with Dots in Keys
+
+**Vault Secret:**
+```json
+{
+  "my.app": {
+    "config.key": "value123"
+  }
+}
+```
+
+**New Format:**
+```
+services?my.app/config.key
+```
+
+**Explanation:**
+- `my.app` is a literal key name (contains dot)
+- `/` traverses into that key
+- `config.key` is another literal key name (contains dot)
+
+### Example 6: Custom Engine Type
+
+**Legacy (no engine type support):**
+```
+old-secrets.api_key
+```
+
+**New Format (KVv1 engine):**
+```
+engine=KVv1#old-secrets?api_key
+```
+
+**Explanation:** The `engine=` prefix specifies KVv1, and `#` is required when using prefixes.
+
+### Example 7: Custom Mount Path
+
+**Legacy (no mount path support):**
+```
+myapp/database.password
+```
+
+**New Format (custom mount):**
+```
+@prod/secrets#myapp/database?password
+```
+
+**Explanation:** The `@` prefix specifies a custom mount path, and `#` is required when using prefixes.
+
+## Detection Logic
+
+The implementation automatically detects which format is being used:
+
+### New Format Indicators
+An alias is considered **new format** if it contains any of:
+- `?` (key path delimiter)
+- `#` (secret path marker)
+- `@` (mount path prefix)
+- Starts with `engine=`
+
+### Legacy Format
+If none of the above indicators are present AND the alias contains a dot (`.`), it is treated as **legacy format** (split on last dot).
+
+**Important:** Legacy format support must be explicitly enabled via the `support-legacy-alias-format` configuration parameter. When disabled (default in stable releases), aliases without new format indicators will be rejected with an error message providing the correct new format.
+
+### Examples
+
+```
+myapp/database?password          → New format (contains ?)
+#myapp/database?password         → New format (contains # and ?)
+@custom#myapp/db?pass            → New format (contains @, #, and ?)
+engine=KVv1#secret?key           → New format (starts with engine=)
+myapp/database.password          → Legacy format (no indicators)
+my.app.config.key                → Legacy format (no indicators)
+```
+
+## Common Migration Scenarios
+
+### Scenario 1: Simple Application
+
+**Before:**
+```xml
+<credential-store name="vault-store" type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault.company.com:8200"/>
+    </implementation-properties>
+</credential-store>
+```
+
+**Aliases:**
+- `myapp/database.password`
+- `myapp/api.key`
+
+**After:**
+```xml
+<credential-store name="vault-store" type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault.company.com:8200"/>
+        <property name="support-legacy-alias-format" value="false"/>
+    </implementation-properties>
+</credential-store>
+```
+
+**New Aliases:**
+- `myapp/database?password`
+- `myapp/api?key`
+
+### Scenario 2: Multiple Applications with Nested Secrets
+
+**Before (flattened structure):**
+
+Vault secrets:
+```json
+{
+  "db_host": "localhost",
+  "db_port": "5432",
+  "db_user": "admin",
+  "db_pass": "secret"
+}
+```
+
+Aliases:
+- `myapp/config.db_host`
+- `myapp/config.db_port`
+- `myapp/config.db_user`
+- `myapp/config.db_pass`
+
+**After (nested structure):**
+
+Vault secrets:
+```json
+{
+  "database": {
+    "host": "localhost",
+    "port": 5432,
+    "credentials": {
+      "user": "admin",
+      "pass": "secret"
+    }
+  }
+}
+```
+
+New aliases:
+- `myapp/config?database/host`
+- `myapp/config?database/port`
+- `myapp/config?database/credentials/user`
+- `myapp/config?database/credentials/pass`
+
+### Scenario 3: Mixed Engine Types
+
+**Before (all KVv2):**
+- `old-app/config.key`
+- `new-app/config.key`
+
+**After (mixed engines):**
+- `engine=KVv1#old-app/config?key` (legacy app uses KVv1)
+- `new-app/config?key` (new app uses KVv2 default)
+
+## Testing Your Migration
+
+### 1. Create a Test Credential Store
+
+```xml
+<credential-store name="vault-store-test"
+                  type="hashicorp-vault">
+    <implementation-properties>
+        <property name="host-address" value="https://vault-test.company.com:8200"/>
+        <property name="support-legacy-alias-format" value="true"/>
+    </implementation-properties>
+</credential-store>
+```
+
+### 2. Test Both Formats Side-by-Side
+
+Create test secrets in Vault:
+```bash
+vault kv put secret/test/migration password=test123
+```
+
+Test both formats:
+- Legacy: `test/migration.password`
+- New: `test/migration?password`
+
+### 3. Verify Retrieval
+
+Use WildFly CLI to test:
+```bash
+/subsystem=elytron/credential-store=vault-store-test:read-alias(alias=test/migration?password)
+```
+
+### 4. Test Application Integration
+
+Deploy your application with the new aliases and verify functionality.
+
+### 5. Monitor Logs
+
+Check for warnings or errors related to alias parsing:
+```bash
+grep -i "vault\|alias" server.log
+```
+
+## Rollback Plan
+
+If you encounter issues during migration:
+
+### 1. Re-enable Legacy Support
+
+```xml
+<property name="support-legacy-alias-format" value="true"/>
+```
+
+### 2. Revert Aliases
+
+Change aliases back to legacy format temporarily.
+
+### 3. Investigate Issues
+
+- Check logs for specific errors
+- Verify Vault secret structure
+- Test individual aliases
+- Review URL encoding
+
+### 4. Retry Migration
+
+Once issues are resolved, retry the migration process.
+
+## Best Practices
+
+### 1. Migrate Gradually
+
+Don't convert all aliases at once. Migrate one application or service at a time.
+
+### 2. Test in Non-Production First
+
+Always test migrations in development or staging environments first.
+
+### 3. Document Your Aliases
+
+Keep a mapping of old to new aliases:
+
+```
+# Migration Mapping
+myapp/database.password → myapp/database?password
+myapp/api.key → myapp/api?key
+services.auth.token → services/auth?token
+```
+
+### 4. Use Nested Paths When Appropriate
+
+Take advantage of nested JSON support to organize secrets better:
+
+**Before:**
+```
+myapp/config.db_host
+myapp/config.db_port
+myapp/config.api_key
+myapp/config.api_secret
+```
+
+**After:**
+```
+myapp/config?database/host
+myapp/config?database/port
+myapp/config?api/key
+myapp/config?api/secret
+```
+
+### 5. Plan for URL Encoding
+
+If your paths contain special characters, plan for URL encoding:
+
+```
+test path → test%20path
+test#path → test%23path
+test?path → test%3Fpath
+```
+
+## Timeline Recommendations
+
+### Week 1-2: Planning
+- Review all existing aliases
+- Identify conversion patterns
+- Plan testing strategy
+- Set up test environment
+
+### Week 3-4: Testing
+- Enable legacy support in test environment
+- Convert and test aliases in test environment
+- Document any issues
+- Refine conversion approach
+
+### Week 5-6: Staging Migration
+- Enable legacy support in staging
+- Convert aliases in staging
+- Test applications thoroughly
+- Monitor for issues
+
+### Week 7-8: Production Migration
+- Enable legacy support in production
+- Convert aliases in production (gradually)
+- Monitor applications closely
+- Keep legacy support enabled
+
+### Week 9+: Cleanup
+- After stable period (2-4 weeks), disable legacy support
+- Remove legacy format documentation from internal docs
+- Update runbooks and procedures
+
+## Troubleshooting
+
+### Issue: Alias Not Found After Conversion
+
+**Symptoms:** Application can't retrieve credential after converting alias.
+
+**Solutions:**
+1. Verify the secret exists in Vault at the specified path
+2. Check for typos in the new alias
+3. Verify URL encoding if path contains special characters
+4. Test the alias using WildFly CLI
+5. Check Vault logs for access attempts
+
+### Issue: Wrong Value Retrieved
+
+**Symptoms:** Credential is retrieved but has wrong value.
+
+**Solutions:**
+1. Verify the key path is correct
+2. Check if you need nested path (`/`) vs simple key
+3. Inspect the actual Vault secret structure
+4. Test key path resolution separately
+
+### Issue: Legacy Format Still Being Used
+
+**Symptoms:** New format aliases not working, legacy format still works.
+
+**Solutions:**
+1. Verify `support-legacy-alias-format` is set correctly
+2. Check if alias contains new format indicators (`?`, `#`, `@`, `engine=`)
+3. Review alias detection logic
+4. Check for configuration caching issues
+
+### Issue: URL Encoding Problems
+
+**Symptoms:** Paths with special characters not working.
+
+**Solutions:**
+1. Verify special characters are URL-encoded (`#` → `%23`, `?` → `%3F`)
+2. Check that spaces are encoded as `%20`
+3. Test with simple paths first, then add encoding
+4. Review URL encoding documentation
+
+## Support and Resources
+
+### Documentation
+- [Alias Format Specification](alias-format.md)
+- [Configuration Guide](configuration.md)
+- [WildFly Elytron Documentation](https://docs.wildfly.org/elytron/)
+
+### Getting Help
+- Check server logs for detailed error messages
+- Review Vault audit logs for access patterns
+- Test aliases using WildFly CLI for debugging
+- Consult WildFly community forums
+
+## Deprecation Timeline
+
+### Current Status
+- **Legacy format:** Supported (with `support-legacy-alias-format=true`)
+- **New format:** Fully supported and recommended
+
+### Future Plans
+- **Next major version:** Legacy format deprecated (warning messages)
+- **Following major version:** Legacy format removed
+
+**Recommendation:** Migrate to new format as soon as practical to avoid future compatibility issues.
+
+## Summary
+
+The new alias format provides significant improvements over the legacy format:
+
+✅ **Unambiguous parsing** - Clear delimiters for all components
+✅ **Nested JSON support** - Access deeply nested values
+✅ **Dots in keys** - No restrictions on naming
+✅ **Multiple engines** - Support for all Vault secret engines
+✅ **Custom mounts** - Flexible mount path configuration
+✅ **Future-proof** - Extensible for new features
+
+Migration is straightforward with legacy format support enabled during the transition period. Follow this guide to ensure a smooth migration process.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -565,6 +565,81 @@ test?path → test%3Fpath
 3. Test with simple paths first, then add encoding
 4. Review URL encoding documentation
 
+### Issue: Checking Logs and Enabling Debug Logging
+
+**When to use:** Any troubleshooting scenario - logs provide detailed information about what's happening.
+
+**Log File Locations:**
+- **Standalone mode:** `$JBOSS_HOME/standalone/log/server.log`
+- **Domain mode:** `$JBOSS_HOME/domain/servers/{server-name}/log/server.log`
+
+**Enable Debug Logging:**
+
+Add to your WildFly configuration (standalone.xml or domain.xml):
+
+```xml
+<subsystem xmlns="urn:jboss:domain:logging:8.0">
+    <logger category="org.wildfly.security.hashicorp.vault">
+        <level name="DEBUG"/>
+    </logger>
+</subsystem>
+```
+
+Or use CLI:
+
+```bash
+/subsystem=logging/logger=org.wildfly.security.hashicorp.vault:add(level=DEBUG)
+reload
+```
+
+**Enable Trace Logging (for detailed operations):**
+
+```bash
+/subsystem=logging/logger=org.wildfly.security.hashicorp.vault:write-attribute(name=level,value=TRACE)
+reload
+```
+
+**What to Look For:**
+
+1. **Configuration Issues:**
+   ```
+   ELYHCVT0024: Failed to configure Vault connection to https://vault.example.com:8200
+   ```
+   Check: host-address, port, TLS settings, authentication
+
+2. **Authentication Problems:**
+   ```
+   ELYHCVT0034: All login strategies failed
+   ```
+   Check: vault token, TLS certificates, authentication-context
+
+3. **Alias Format Issues:**
+   ```
+   ELYHCVT0074: Invalid alias format: ...
+   ```
+   Check: alias syntax, delimiters, URL encoding
+
+4. **Secret Not Found:**
+   ```
+   ELYHCVT0029: Secret not found at path: secret/myapp/database
+   ```
+   Check: path exists in Vault, permissions, KV version
+
+5. **Legacy Format Warnings:**
+   ```
+   ELYHCVT0072: Legacy alias format detected: 'secret.myapp.password'
+   ```
+   Action: Migrate to new format
+
+**Troubleshooting Workflow:**
+
+1. Check server.log for ELYHCVT error codes
+2. Enable DEBUG logging if needed
+3. Reproduce the issue
+4. Look for error messages with context
+5. Enable TRACE logging for detailed operation flow
+6. Check Vault audit logs for corresponding access attempts
+
 ## Support and Resources
 
 ### Documentation

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import javax.net.ssl.SSLContext;
 
@@ -44,6 +45,8 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
     private static final int DEFAULT_CREDENTIAL_CACHE_MAX_SIZE = 500;
     private static List<Class<? extends CredentialStoreExtension>> SUPPORTED_EXTENSION_TYPES =
             List.of(HashicorpVaultCredentialStoreExtension.class);
+    /** Default predicate that always returns false (use KV v2 for all paths). */
+    private static final Predicate<String> DEFAULT_KV_V1_FALLBACK_PREDICATE = path -> false;
 
     String hostAddress;
     String namespace;
@@ -55,6 +58,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
     private String keyStorePass;
     private String trustStorePass;
     private SSLContext sslContext;
+    private Predicate<String> kvV1FallbackPredicate = DEFAULT_KV_V1_FALLBACK_PREDICATE;
 
     /** In-memory LRU cache of retrieved credentials, keyed by credential alias (e.g. "path.key"). */
     private Map<String, Credential> credentialCache;
@@ -144,7 +148,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
                 }
             }
 
-            vaultConnector = new VaultConnector(this.hostAddress, token, this.namespace, sslConfig, true, sslContext);
+            vaultConnector = new VaultConnector(this.hostAddress, token, this.namespace, sslConfig, true, sslContext, kvV1FallbackPredicate);
             vaultConnector.configure();
 
             initialized = true;
@@ -157,6 +161,10 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
 
     public void setSslContext(SSLContext sslContext) {
         this.sslContext = sslContext;
+    }
+
+    public void setKvV1FallbackPredicate(Predicate<String> kvV1FallbackPredicate) {
+        this.kvV1FallbackPredicate = kvV1FallbackPredicate != null ? kvV1FallbackPredicate : DEFAULT_KV_V1_FALLBACK_PREDICATE;
     }
 
     @Override
@@ -375,6 +383,11 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         @Override
         public void setSslContext(SSLContext sslContext) {
             HashicorpVaultCredentialStore.this.setSslContext(sslContext);
+        }
+
+        @Override
+        public void setKvV1FallbackPredicate(Predicate<String> kvV1FallbackPredicate) {
+            HashicorpVaultCredentialStore.this.setKvV1FallbackPredicate(kvV1FallbackPredicate);
         }
 
         @Override

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -63,6 +63,15 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
     /** In-memory LRU cache of retrieved credentials, keyed by credential alias (e.g. "path.key"). */
     private Map<String, Credential> credentialCache;
 
+    /** Whether to support legacy alias format (secret-path.key). Defaults to false. */
+    private boolean supportLegacyAliasFormat = false;
+
+    /** Default engine type to use when not specified in alias. */
+    private String defaultEngineType = "KVv2";
+
+    /** Default mount path to use when not specified in alias. */
+    private String defaultMountPath = "secret";
+
 
     @Override
     public void initialize(Map<String, String> attributes, CredentialStore.ProtectionParameter protectionParameter, Provider[] providers) throws CredentialStoreException {
@@ -95,6 +104,19 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         this.namespace = attributes.get("namespace");
         this.protectionParameter = protectionParameter;
         this.providers = providers;
+
+        // Parse new configuration parameters
+        if (attributes.get("support-legacy-alias-format") != null) {
+            this.supportLegacyAliasFormat = Boolean.parseBoolean(attributes.get("support-legacy-alias-format"));
+        }
+
+        if (attributes.get("default-engine-type") != null) {
+            this.defaultEngineType = attributes.get("default-engine-type");
+        }
+
+        if (attributes.get("default-mount-path") != null) {
+            this.defaultMountPath = attributes.get("default-mount-path");
+        }
 
         this.credentialCache = Collections.synchronizedMap(new LinkedHashMap<String, Credential>(16, 0.75f, true) {
             @Override

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -33,7 +33,41 @@ import org.wildfly.security.password.interfaces.ClearPassword;
 import io.github.jopenlibs.vault.SslConfig;
 
 /**
- * Credential store backed by Hashicorp Vault
+ * Credential store backed by HashiCorp Vault.
+ *
+ * <p>This credential store integrates with HashiCorp Vault to securely retrieve credentials.
+ * It supports the new structured alias format with nested JSON path traversal, as well as
+ * optional backward compatibility with the legacy format.
+ *
+ * <h2>Alias Format</h2>
+ * <p>The new alias format is:
+ * <pre>{@code [engine=TYPE][@mount-path][#]secret-path?key-path}</pre>
+ *
+ * <p>Examples:
+ * <ul>
+ *   <li>{@code myapp/database?password} - Simple key</li>
+ *   <li>{@code myapp/config?database/host} - Nested JSON path</li>
+ *   <li>{@code engine=KVv1#old-app/config?api_key} - Explicit engine type</li>
+ *   <li>{@code @prod/secrets#myapp/db?password} - Custom mount path</li>
+ * </ul>
+ *
+ * <h2>Configuration Parameters</h2>
+ * <ul>
+ *   <li>{@code host-address} (required) - Vault server URL</li>
+ *   <li>{@code namespace} (optional) - Vault namespace (Enterprise)</li>
+ *   <li>{@code trust-store-path} (optional) - Path to trust store for TLS</li>
+ *   <li>{@code key-store-path} (optional) - Path to key store for mutual TLS</li>
+ *   <li>{@code key-store-pass} (optional) - Key store password</li>
+ *   <li>{@code trust-store-pass} (optional) - Trust store password</li>
+ *   <li>{@code support-legacy-alias-format} (optional) - Enable legacy format support (default: false)</li>
+ *   <li>{@code default-engine-type} (optional) - Default engine type (default: KVv2)</li>
+ *   <li>{@code default-mount-path} (optional) - Default mount path (default: secret)</li>
+ * </ul>
+ *
+ * <p>For complete documentation, see the project documentation in the {@code docs/} directory.
+ *
+ * @see VaultAlias
+ * @see KeyPathResolver
  */
 public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
 

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -368,11 +368,30 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
 
     /**
      * Get aliases from a specific path in Vault with optional recursive traversal.
+     * <p>
+     * Path format depends on the {@code supportLegacyAliasFormat} configuration:
+     * <ul>
+     *   <li><b>New format</b> (always supported):
+     *     <ul>
+     *       <li>{@code @mount#secretpath} - explicit mount and secret path</li>
+     *       <li>{@code #secretpath} - default mount with secret path</li>
+     *       <li>{@code secretpath} - default mount with secret path (# is optional)</li>
+     *       <li>{@code /} or {@code ""} - root of default mount</li>
+     *       <li>{@code @mount#} or {@code @mount#/} - root of explicit mount</li>
+     *     </ul>
+     *   </li>
+     *   <li><b>Legacy format</b> (only when {@code supportLegacyAliasFormat=true}):
+     *     <ul>
+     *       <li>{@code mount/secretpath} - mount point and secret path separated by first /</li>
+     *       <li>{@code mount/} - root of mount point</li>
+     *     </ul>
+     *   </li>
+     * </ul>
      *
      * @param path the Vault path to start listing from. If null or empty, throw exception
      * @param recursive if true, traverse subpaths; if false, only list aliases at the specified path
      * @return set of aliases in format "path.key", containing at most 10,000 aliases
-     * @throws CredentialStoreException if listing aliases fails
+     * @throws CredentialStoreException if listing aliases fails or if legacy format is used when not supported
      */
     public Set<String> getAliases(String path, boolean recursive) throws CredentialStoreException {
         if (!initialized) {
@@ -386,13 +405,32 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
 
     /**
      * Get aliases from a specific path in Vault with optional recursive traversal.
+     * <p>
+     * Path format depends on the {@code supportLegacyAliasFormat} configuration:
+     * <ul>
+     *   <li><b>New format</b> (always supported):
+     *     <ul>
+     *       <li>{@code @mount#secretpath} - explicit mount and secret path</li>
+     *       <li>{@code #secretpath} - default mount with secret path</li>
+     *       <li>{@code secretpath} - default mount with secret path (# is optional)</li>
+     *       <li>{@code /} or {@code ""} - root of default mount</li>
+     *       <li>{@code @mount#} or {@code @mount#/} - root of explicit mount</li>
+     *     </ul>
+     *   </li>
+     *   <li><b>Legacy format</b> (only when {@code supportLegacyAliasFormat=true}):
+     *     <ul>
+     *       <li>{@code mount/secretpath} - mount point and secret path separated by first /</li>
+     *       <li>{@code mount/} - root of mount point</li>
+     *     </ul>
+     *   </li>
+     * </ul>
      *
      * @param path the Vault path to start listing from. If null or empty, throw exception
      * @param recursive if true, traverse subpaths; if false, only list aliases at the specified path
      * @param recursiveDepth the maximum depth to traverse if recursive is true. 0 means only the specified path,
      *                       1 means one level deep, etc. Ignored if recursive is false.
      * @return set of aliases in format "path.key", containing at most 10,000 aliases
-     * @throws CredentialStoreException if listing aliases fails
+     * @throws CredentialStoreException if listing aliases fails or if legacy format is used when not supported
      */
     public Set<String> getAliases(String path, boolean recursive, int recursiveDepth) throws CredentialStoreException {
         if (!initialized) {
@@ -404,7 +442,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         if (recursiveDepth < 0) {
             throw ROOT_LOGGER.recursiveDepthMustBeNonNegative(recursiveDepth);
         }
-        return collectAliases(normalizePath(path), recursive, recursiveDepth);
+        return collectAliases(path, recursive, recursiveDepth);
     }
 
     /**
@@ -431,7 +469,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         if (maxNumberOfAliases <= 0) {
             throw ROOT_LOGGER.maxNumberOfAliasesMustBePositive(maxNumberOfAliases);
         }
-        return collectAliases(normalizePath(path), recursive, recursiveDepth, maxNumberOfAliases);
+        return collectAliases(path, recursive, recursiveDepth, maxNumberOfAliases);
     }
 
     private final HashicorpVaultCredentialStoreExtension credentialStoreExtension = new HashicorpVaultCredentialStoreExtension() {
@@ -511,18 +549,41 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         String mountPath = defaultMountPath;
         String secretPath = path;
 
-        if (path.startsWith("@")) {
+        if (path.equals("/") || path.isEmpty()) {
+            // Special case: "/" or "" means root of default mount (new format)
+            secretPath = "";
+        } else if (path.startsWith("@")) {
+            // New format with explicit mount: @mount#secretpath
             int hashIndex = path.indexOf('#');
             if (hashIndex > 0) {
                 mountPath = path.substring(1, hashIndex);
                 secretPath = path.substring(hashIndex + 1);
             }
         } else if (path.startsWith("#")) {
+            // New format with default mount: #secretpath
             secretPath = path.substring(1);
         } else if (path.contains("/")) {
-            int firstSlash = path.indexOf('/');
-            mountPath = path.substring(0, firstSlash);
-            secretPath = path.substring(firstSlash + 1);
+            // Could be legacy format: mount/secretpath
+            if (supportLegacyAliasFormat) {
+                // Legacy format enabled - parse as mount/secretpath
+                int firstSlash = path.indexOf('/');
+                mountPath = path.substring(0, firstSlash);
+                secretPath = path.substring(firstSlash + 1);
+            } else {
+                // Legacy format disabled - reject with clear error
+                throw ROOT_LOGGER.legacyPathFormatNotSupported(path);
+            }
+        } else {
+            // Path has no delimiters - could be:
+            // 1. A secret name using default mount (new format)
+            // 2. A mount name for root listing (legacy format, but trailing / was normalized away)
+            // Since we can't distinguish these cases after normalization, treat as secret name
+            secretPath = path;
+        }
+
+        // Handle empty secret path (root listing)
+        if (secretPath.isEmpty() || secretPath.equals("/")) {
+            secretPath = "";  // Normalize to empty for root
         }
 
         // First, try to get keys for the secret at this exact path

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -17,7 +17,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
 
 import javax.net.ssl.SSLContext;
 
@@ -77,9 +76,6 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
     private static final int DEFAULT_CREDENTIAL_CACHE_MAX_SIZE = 500;
     private static List<Class<? extends CredentialStoreExtension>> SUPPORTED_EXTENSION_TYPES =
             List.of(HashicorpVaultCredentialStoreExtension.class);
-    /** Default predicate that always returns false (use KV v2 for all paths). */
-    private static final Predicate<String> DEFAULT_KV_V1_FALLBACK_PREDICATE = path -> false;
-
     String hostAddress;
     String namespace;
     CredentialStore.ProtectionParameter protectionParameter;
@@ -90,7 +86,6 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
     private String keyStorePass;
     private String trustStorePass;
     private SSLContext sslContext;
-    private Predicate<String> kvV1FallbackPredicate = DEFAULT_KV_V1_FALLBACK_PREDICATE;
 
     /** In-memory LRU cache of retrieved credentials, keyed by credential alias (e.g. "path.key"). */
     private Map<String, Credential> credentialCache;
@@ -206,7 +201,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
                 }
             }
 
-            vaultConnector = new VaultConnector(this.hostAddress, token, this.namespace, sslConfig, true, sslContext, kvV1FallbackPredicate);
+            vaultConnector = new VaultConnector(this.hostAddress, token, this.namespace, sslConfig, true, sslContext);
             vaultConnector.configure();
 
             initialized = true;
@@ -217,10 +212,6 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
 
     public void setSslContext(SSLContext sslContext) {
         this.sslContext = sslContext;
-    }
-
-    public void setKvV1FallbackPredicate(Predicate<String> kvV1FallbackPredicate) {
-        this.kvV1FallbackPredicate = kvV1FallbackPredicate != null ? kvV1FallbackPredicate : DEFAULT_KV_V1_FALLBACK_PREDICATE;
     }
 
     @Override
@@ -447,11 +438,6 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         @Override
         public void setSslContext(SSLContext sslContext) {
             HashicorpVaultCredentialStore.this.setSslContext(sslContext);
-        }
-
-        @Override
-        public void setKvV1FallbackPredicate(Predicate<String> kvV1FallbackPredicate) {
-            HashicorpVaultCredentialStore.this.setKvV1FallbackPredicate(kvV1FallbackPredicate);
         }
 
         @Override

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -315,7 +315,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
      * @throws CredentialStoreException if parsing fails
      */
     private VaultAlias parseAlias(String credentialAlias) throws CredentialStoreException {
-        return VaultAlias.parseWithLegacySupport(
+        return VaultAlias.parse(
             credentialAlias,
             this.defaultEngineType,
             this.defaultMountPath,
@@ -526,71 +526,57 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
     /**
      * Recursively collect aliases from Vault using the new alias format.
      *
-     * This implementation:
-     * - Parses the input path to extract mount and secret path
-     * - Lists secrets at the current path
-     * - For each secret, gets all keys and creates aliases in new format
-     * - Recursively traverses subdirectories if enabled
+     * <p>This implementation:
+     * <ul>
+     *   <li>Parses the input path to extract engine type, mount path, and secret path</li>
+     *   <li>Lists secrets at the current path</li>
+     *   <li>For each secret, gets all keys and creates aliases in new format</li>
+     *   <li>Recursively traverses subdirectories if enabled</li>
+     * </ul>
      *
-     * @param path the path to list (legacy format like "secret/myapp" or new format like "@secret#myapp")
+     * <p>Supported path formats:
+     * <ul>
+     *   <li>{@code engine=TYPE@mount#secretpath} - Full specification with engine type</li>
+     *   <li>{@code @mount#secretpath} - Explicit mount with default engine type</li>
+     *   <li>{@code #secretpath} - Default mount and engine type</li>
+     *   <li>{@code secretpath} - Minimal format (# is optional)</li>
+     *   <li>{@code mount/secretpath} - Legacy format (only when {@code supportLegacyAliasFormat=true})</li>
+     * </ul>
+     *
+     * @param path the path to list in any supported format
      * @param aliases the set to collect aliases into
      * @param recursive whether to recurse into subdirectories
      * @param maxDepth maximum recursion depth
      * @param currentDepth current recursion depth
      * @param maxNumberOfAliases maximum number of aliases to collect
-     * @throws CredentialStoreException if listing fails
+     * @throws CredentialStoreException if listing fails or path format is invalid
      */
     private void collectAliasesRecursive(String path, Set<String> aliases, boolean recursive, int maxDepth, int currentDepth, int maxNumberOfAliases) throws CredentialStoreException {
         if (aliases.size() >= maxNumberOfAliases) {
             return;
         }
 
-        // Parse the path to extract mount and secret path
-        String mountPath = defaultMountPath;
-        String secretPath = path;
-
-        if (path.equals("/") || path.isEmpty()) {
-            // Special case: "/" or "" means root of default mount (new format)
-            secretPath = "";
-        } else if (path.startsWith("@")) {
-            // New format with explicit mount: @mount#secretpath
-            int hashIndex = path.indexOf('#');
-            if (hashIndex > 0) {
-                mountPath = path.substring(1, hashIndex);
-                secretPath = path.substring(hashIndex + 1);
-            }
-        } else if (path.startsWith("#")) {
-            // New format with default mount: #secretpath
-            secretPath = path.substring(1);
-        } else if (path.contains("/")) {
-            // Could be legacy format: mount/secretpath
-            if (supportLegacyAliasFormat) {
-                // Legacy format enabled - parse as mount/secretpath
-                int firstSlash = path.indexOf('/');
-                mountPath = path.substring(0, firstSlash);
-                secretPath = path.substring(firstSlash + 1);
-            } else {
-                // Legacy format disabled - reject with clear error
-                throw ROOT_LOGGER.legacyPathFormatNotSupported(path);
-            }
-        } else {
-            // Path has no delimiters - could be:
-            // 1. A secret name using default mount (new format)
-            // 2. A mount name for root listing (legacy format, but trailing / was normalized away)
-            // Since we can't distinguish these cases after normalization, treat as secret name
-            secretPath = path;
+        // Parse the path using VaultPath to extract mount and secret path
+        // This handles all formats: engine=TYPE@mount#secretpath, @mount#secretpath,
+        // #secretpath, secretpath, and legacy mount/secretpath (when enabled)
+        VaultPath vaultPath;
+        try {
+            vaultPath = VaultPath.parse(path != null ? path : "", defaultEngineType, defaultMountPath, supportLegacyAliasFormat);
+        } catch (CredentialStoreException e) {
+            // Invalid path format, cannot proceed
+            ROOT_LOGGER.tracef(e, "Failed to parse path '%s'", path);
+            return;
         }
 
-        // Handle empty secret path (root listing)
-        if (secretPath.isEmpty() || secretPath.equals("/")) {
-            secretPath = "";  // Normalize to empty for root
-        }
+        String mountPath = vaultPath.getMountPath();
+        String secretPath = vaultPath.getSecretPath();
+        String engineType = vaultPath.getEngineType();
 
         // First, try to get keys for the secret at this exact path
         // This handles the case where the path itself is a secret (e.g., "app1")
         try {
-            VaultAlias alias = VaultAlias.create(defaultEngineType, mountPath, secretPath, "_placeholder");
-            List<String> keys = vaultConnector.getKeysForSecret(alias);
+            VaultPath secretVaultPath = VaultPath.create(engineType, mountPath, secretPath);
+            List<String> keys = vaultConnector.getKeysForSecret(secretVaultPath);
             if (keys != null && !keys.isEmpty()) {
                 for (String key : keys) {
                     if (aliases.size() >= maxNumberOfAliases) return;
@@ -622,8 +608,8 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
                             // Secret - get its keys
                             String fullPath = secretPath.isEmpty() ? item : secretPath + "/" + item;
                             try {
-                                VaultAlias alias = VaultAlias.create(defaultEngineType, mountPath, fullPath, "_placeholder");
-                                List<String> keys = vaultConnector.getKeysForSecret(alias);
+                                VaultPath childVaultPath = VaultPath.create(engineType, mountPath, fullPath);
+                                List<String> keys = vaultConnector.getKeysForSecret(childVaultPath);
                                 if (keys != null) {
                                     for (String key : keys) {
                                         if (aliases.size() >= maxNumberOfAliases) return;

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -499,79 +499,103 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         return aliases;
     }
 
-    // TODO: Implement alias listing with new alias format
-    // Keep an eye on https://github.com/hashicorp/vault/issues/5275 and remove this logic once hashicorp vault provides this operation
-    // This method needs to be redesigned to work with the new alias format that supports:
-    // - Custom mount paths (not just "secret")
-    // - Nested JSON key paths (not just top-level keys)
-    // - Different engine types (KVv1 vs KVv2)
-    // The current implementation assumes legacy "path.key" format and needs VaultConnector methods that were removed.
+    /**
+     * Recursively collect aliases from Vault using the new alias format.
+     *
+     * This implementation:
+     * - Parses the input path to extract mount and secret path
+     * - Lists secrets at the current path
+     * - For each secret, gets all keys and creates aliases in new format
+     * - Recursively traverses subdirectories if enabled
+     *
+     * @param path the path to list (legacy format like "secret/myapp" or new format like "@secret#myapp")
+     * @param aliases the set to collect aliases into
+     * @param recursive whether to recurse into subdirectories
+     * @param maxDepth maximum recursion depth
+     * @param currentDepth current recursion depth
+     * @param maxNumberOfAliases maximum number of aliases to collect
+     * @throws CredentialStoreException if listing fails
+     */
     private void collectAliasesRecursive(String path, Set<String> aliases, boolean recursive, int maxDepth, int currentDepth, int maxNumberOfAliases) throws CredentialStoreException {
-        throw new UnsupportedOperationException(
-            "Alias listing is not yet implemented for the new alias format. " +
-            "This feature requires redesign to support custom mount paths, nested JSON keys, and different engine types. " +
-            "For now, you must know your alias names explicitly. " +
-            "See https://github.com/wildfly-security/wildfly-elytron-hashicorp-vault/issues/70 for tracking."
-        );
-
-        // Original implementation (commented out - requires removed VaultConnector methods):
-        /*
         if (aliases.size() >= maxNumberOfAliases) {
             return;
         }
 
-        try {
-            Set<String> keys = vaultConnector.getKeysForPath(path);
-            for (String key : keys) {
-                if (aliases.size() >= maxNumberOfAliases) {
-                    return;
-                }
-                aliases.add(path + "." + key);
+        // Parse the path to extract mount and secret path
+        String mountPath = defaultMountPath;
+        String secretPath = path;
+
+        if (path.startsWith("@")) {
+            int hashIndex = path.indexOf('#');
+            if (hashIndex > 0) {
+                mountPath = path.substring(1, hashIndex);
+                secretPath = path.substring(hashIndex + 1);
             }
-        } catch (VaultException e) {
-            if (e.getMessage() != null && e.getMessage().contains("Path does not exist")) {
-                // ignore because this path in the tree can be empty, but other paths not so continue traversal
-            } else {
-                throw ROOT_LOGGER.couldNotReadKeysFromPath(path, currentDepth, recursive, e.getMessage(), e);
-            }
+        } else if (path.startsWith("#")) {
+            secretPath = path.substring(1);
+        } else if (path.contains("/")) {
+            int firstSlash = path.indexOf('/');
+            mountPath = path.substring(0, firstSlash);
+            secretPath = path.substring(firstSlash + 1);
         }
 
-        if (recursive && currentDepth < maxDepth && aliases.size() < maxNumberOfAliases) {
-            try {
-                Set<String> items = vaultConnector.listAllItemsAtPath(path);
-                if (items.isEmpty()) {
-                    return;
-                }
-                for (String item : items) {
-                    if (aliases.size() >= maxNumberOfAliases) {
-                        return;
-                    }
-                    String fullItemPath = normalizePath(path) + "/" + item;
-                    boolean isSubpath = item.endsWith("/");
-                    if (!isSubpath) {
-                        try {
-                            Set<String> keys = vaultConnector.getKeysForPath(fullItemPath);
-                            for (String key : keys) {
-                                if (aliases.size() >= maxNumberOfAliases) {
-                                    return;
-                                }
-                                aliases.add(fullItemPath + "." + key);
-                            }
-                        } catch (VaultException e) {
-                            // Path doesn't have keys or doesn't exist - continue with other paths
-                        }
-                    } else {
-                        collectAliasesRecursive(fullItemPath, aliases, recursive, maxDepth, currentDepth + 1, maxNumberOfAliases);
-                    }
-                }
-            } catch (VaultException e) {
-                String errorMsg = e.getMessage();
-                if (errorMsg != null && errorMsg.contains("403")) {
-                    throw ROOT_LOGGER.forbiddenToListSubpathsAtCredentialStorePath(path, e);
+        // First, try to get keys for the secret at this exact path
+        // This handles the case where the path itself is a secret (e.g., "app1")
+        try {
+            VaultAlias alias = VaultAlias.create(defaultEngineType, mountPath, secretPath, "_placeholder");
+            List<String> keys = vaultConnector.getKeysForSecret(alias);
+            if (keys != null && !keys.isEmpty()) {
+                for (String key : keys) {
+                    if (aliases.size() >= maxNumberOfAliases) return;
+                    aliases.add("#" + secretPath + "?" + key);
                 }
             }
+        } catch (CredentialStoreException e) {
+            // No secret at this path, continue
+            ROOT_LOGGER.tracef(e, "No secret found at path '%s', continuing to check subdirectories", secretPath);
         }
-        */
+
+        // If recursive and we haven't exceeded depth, list subdirectories
+        if (recursive && currentDepth < maxDepth) {
+            try {
+                // List items under this path
+                List<String> items = vaultConnector.listSecretsAtPath(mountPath, secretPath, defaultEngineType);
+
+                if (items != null && !items.isEmpty()) {
+                    // Process items from LIST
+                    for (String item : items) {
+                        if (aliases.size() >= maxNumberOfAliases) return;
+
+                        if (item.endsWith("/")) {
+                            // Subdirectory - recurse into it
+                            String subdirName = item.substring(0, item.length() - 1);
+                            String fullPath = secretPath.isEmpty() ? subdirName : secretPath + "/" + subdirName;
+                            collectAliasesRecursive("@" + mountPath + "#" + fullPath, aliases, recursive, maxDepth, currentDepth + 1, maxNumberOfAliases);
+                        } else {
+                            // Secret - get its keys
+                            String fullPath = secretPath.isEmpty() ? item : secretPath + "/" + item;
+                            try {
+                                VaultAlias alias = VaultAlias.create(defaultEngineType, mountPath, fullPath, "_placeholder");
+                                List<String> keys = vaultConnector.getKeysForSecret(alias);
+                                if (keys != null) {
+                                    for (String key : keys) {
+                                        if (aliases.size() >= maxNumberOfAliases) return;
+                                        aliases.add("#" + fullPath + "?" + key);
+                                    }
+                                }
+                            } catch (CredentialStoreException e) {
+                                // Could not get keys for this secret, continue
+                                ROOT_LOGGER.tracef(e, "Could not read secret at path '%s', skipping", fullPath);
+                            }
+                        }
+                    }
+                }
+            } catch (CredentialStoreException e) {
+                // Re-throw the exception - if recursive listing fails (e.g., due to permissions),
+                // the caller should be notified
+                throw e;
+            }
+        }
     }
 
     private String normalizePath(String path) {

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -112,6 +112,10 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
 
         if (attributes.get("default-engine-type") != null) {
             this.defaultEngineType = attributes.get("default-engine-type");
+            // Validate engine type
+            if (!this.defaultEngineType.equals("KVv1") && !this.defaultEngineType.equals("KVv2")) {
+                throw ROOT_LOGGER.invalidDefaultEngineType(this.defaultEngineType);
+            }
         }
 
         if (attributes.get("default-mount-path") != null) {

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -23,7 +23,6 @@ import javax.net.ssl.SSLContext;
 
 import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.PasswordCredential;
-import org.wildfly.security.credential.source.CredentialSource;
 import org.wildfly.security.credential.store.CredentialStore;
 import org.wildfly.security.credential.store.CredentialStoreException;
 import org.wildfly.security.credential.store.CredentialStoreExtension;
@@ -32,7 +31,6 @@ import org.wildfly.security.credential.store.UnsupportedCredentialTypeException;
 import org.wildfly.security.password.interfaces.ClearPassword;
 
 import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.VaultException;
 
 /**
  * Credential store backed by Hashicorp Vault
@@ -180,8 +178,6 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
             initialized = true;
         } catch (IOException e) {
             throw ROOT_LOGGER.failedToInitializeVaultCredentialStore(e);
-        } catch (VaultException e) {
-            throw ROOT_LOGGER.failedToConfigureVaultConnection(e);
         }
     }
 
@@ -210,21 +206,15 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
             throw ROOT_LOGGER.credentialCannotBeNull();
         }
 
-        // Parse credentialAlias in format "path.key"
-        String[] aliasSplit = credentialAlias.split("\\.");
-        if (aliasSplit.length != 2) {
-            throw ROOT_LOGGER.credentialAliasInvalidFormat(credentialAlias);
-        }
+        VaultAlias alias = parseAlias(credentialAlias);
 
         try {
             final char[] chars = credential.castAndApply(PasswordCredential.class, c -> c.getPassword().castAndApply(ClearPassword.class, ClearPassword::getPassword));
             if (chars == null) {
                 throw ROOT_LOGGER.failedToExtractPasswordFromCredential();
             }
-            vaultConnector.putSecret(aliasSplit[0], aliasSplit[1], new String(chars));
+            vaultConnector.putSecretData(alias, new String(chars));
             putInCredentialCache(credentialAlias, credential);
-        } catch (VaultException e) {
-            throw ROOT_LOGGER.failedToStoreCredentialInVault(e);
         } catch (ClassCastException e) {
             throw ROOT_LOGGER.onlyPasswordCredentialWithClearPasswordSupported(e);
         }
@@ -239,12 +229,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
             throw ROOT_LOGGER.credentialAliasRequired();
         }
 
-        // Parse credentialAlias in format "path.key"
-        String[] aliasSplit = credentialAlias.split("\\.");
-        if (aliasSplit.length != 2) {
-            throw ROOT_LOGGER.credentialAliasInvalidFormat(credentialAlias);
-        }
-
+        // Check cache first
         Credential cached;
         synchronized (credentialCache) {
             cached = credentialCache.get(credentialAlias);
@@ -253,16 +238,25 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
             return credentialType.cast(cached);
         }
 
+        VaultAlias alias = parseAlias(credentialAlias);
+
         try {
-            CredentialSource credentialSource = new VaultCredentialSource(vaultConnector, aliasSplit[0], aliasSplit[1]);
-            PasswordCredential credential = credentialSource.getCredential(PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null);
-            if (credential == null) {
-                return null; // Secret not found or key not found in secret
+            // Retrieve full secret data from Vault
+            Map<String, Object> secretData = vaultConnector.getSecretData(alias);
+            if (secretData == null) {
+                return null; // Secret not found
             }
+
+            // Resolve the specific value using key path
+            String value = KeyPathResolver.resolveKeyPath(secretData, alias.getKeyPath());
+            if (value == null) {
+                return null; // Key not found in secret
+            }
+
+            // Create credential from the value
+            PasswordCredential credential = new PasswordCredential(ClearPassword.createRaw(ClearPassword.ALGORITHM_CLEAR, value.toCharArray()));
             putInCredentialCache(credentialAlias, credential);
             return credentialType.cast(credential);
-        } catch (IOException e) {
-            throw ROOT_LOGGER.failedToRetrieveCredentialFromVault(e);
         } catch (ClassCastException e) {
             throw ROOT_LOGGER.unsupportedCredentialType(credentialType.getSimpleName(), e);
         }
@@ -277,21 +271,31 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
             throw ROOT_LOGGER.credentialAliasRequired();
         }
 
-        // Parse credentialAlias in format "path.key"
-        String[] aliasSplit = credentialAlias.split("\\.");
-        if (aliasSplit.length != 2) {
-            throw ROOT_LOGGER.credentialAliasInvalidFormat(credentialAlias);
-        }
+        VaultAlias alias = parseAlias(credentialAlias);
 
-        try {
-            vaultConnector.removeSecret(aliasSplit[0], aliasSplit[1]);
-            synchronized (credentialCache) {
-                // we need to remove whole path because that is how the vault's removeSecret operation works
-                credentialCache.keySet().removeIf(k -> k.equals(credentialAlias) || k.startsWith(aliasSplit[0] + "."));
-            }
-        } catch (VaultException e) {
-            throw ROOT_LOGGER.failedToRemoveCredentialFromVault(e);
+        vaultConnector.removeSecretData(alias);
+        synchronized (credentialCache) {
+            // Remove from cache - just this specific alias
+            // Note: If the removal empties the secret, other keys at same path are also removed from Vault
+            credentialCache.remove(credentialAlias);
         }
+    }
+
+    /**
+     * Parse a credential alias string into a VaultAlias object.
+     * Supports both new alias format and legacy format (if enabled).
+     *
+     * @param credentialAlias the alias string to parse
+     * @return parsed VaultAlias object
+     * @throws CredentialStoreException if parsing fails
+     */
+    private VaultAlias parseAlias(String credentialAlias) throws CredentialStoreException {
+        return VaultAlias.parseWithLegacySupport(
+            credentialAlias,
+            this.defaultEngineType,
+            this.defaultMountPath,
+            this.supportLegacyAliasFormat
+        );
     }
 
     private void putInCredentialCache(String alias, Credential credential) {
@@ -461,8 +465,23 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         return aliases;
     }
 
+    // TODO: Implement alias listing with new alias format
     // Keep an eye on https://github.com/hashicorp/vault/issues/5275 and remove this logic once hashicorp vault provides this operation
+    // This method needs to be redesigned to work with the new alias format that supports:
+    // - Custom mount paths (not just "secret")
+    // - Nested JSON key paths (not just top-level keys)
+    // - Different engine types (KVv1 vs KVv2)
+    // The current implementation assumes legacy "path.key" format and needs VaultConnector methods that were removed.
     private void collectAliasesRecursive(String path, Set<String> aliases, boolean recursive, int maxDepth, int currentDepth, int maxNumberOfAliases) throws CredentialStoreException {
+        throw new UnsupportedOperationException(
+            "Alias listing is not yet implemented for the new alias format. " +
+            "This feature requires redesign to support custom mount paths, nested JSON keys, and different engine types. " +
+            "For now, you must know your alias names explicitly. " +
+            "See https://github.com/wildfly-security/wildfly-elytron-hashicorp-vault/issues/70 for tracking."
+        );
+
+        // Original implementation (commented out - requires removed VaultConnector methods):
+        /*
         if (aliases.size() >= maxNumberOfAliases) {
             return;
         }
@@ -518,6 +537,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
                 }
             }
         }
+        */
     }
 
     private String normalizePath(String path) {

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -4,32 +4,34 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.VaultException;
-import org.wildfly.security.credential.Credential;
-import org.wildfly.security.credential.PasswordCredential;
-import org.wildfly.security.credential.source.CredentialSource;
-import org.wildfly.security.credential.store.CredentialStore;
-import org.wildfly.security.credential.store.CredentialStoreExtension;
-import org.wildfly.security.credential.store.CredentialStoreException;
-import org.wildfly.security.credential.store.CredentialStoreSpi;
-import org.wildfly.security.credential.store.UnsupportedCredentialTypeException;
-import org.wildfly.security.password.interfaces.ClearPassword;
+import static org.wildfly.security.credential.store._private.ElytronMessages.log;
+import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger.ROOT_LOGGER;
 
-import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.security.Provider;
 import java.security.spec.AlgorithmParameterSpec;
-import java.util.HashSet;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.wildfly.security.credential.store._private.ElytronMessages.log;
-import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger.ROOT_LOGGER;
+import javax.net.ssl.SSLContext;
+
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.source.CredentialSource;
+import org.wildfly.security.credential.store.CredentialStore;
+import org.wildfly.security.credential.store.CredentialStoreException;
+import org.wildfly.security.credential.store.CredentialStoreExtension;
+import org.wildfly.security.credential.store.CredentialStoreSpi;
+import org.wildfly.security.credential.store.UnsupportedCredentialTypeException;
+import org.wildfly.security.password.interfaces.ClearPassword;
+
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
 
 /**
  * Credential store backed by Hashicorp Vault
@@ -63,7 +65,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         if (attributes == null) {
             throw ROOT_LOGGER.attributesCannotBeNull();
         }
-        
+
         // Check required attributes
         this.hostAddress = attributes.get("host-address");
         if (this.hostAddress == null || this.hostAddress.trim().isEmpty()) {
@@ -85,7 +87,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         if (attributes.get("trust-store-pass") != null) {
             this.trustStorePass = attributes.get("trust-store-pass");
         }
-        
+
         this.namespace = attributes.get("namespace");
         this.protectionParameter = protectionParameter;
         this.providers = providers;
@@ -108,14 +110,14 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
             }
 
             SslConfig sslConfig = new SslConfig().verify(true);
-            
+
             if (this.keyStorePath != null && !this.keyStorePath.trim().isEmpty()) {
                 try {
                     KeyStore keyStore = KeyStore.getInstance("JKS");
                     try (java.io.FileInputStream fis = new java.io.FileInputStream(this.keyStorePath)) {
                         keyStore.load(fis, this.keyStorePass != null ? this.keyStorePass.toCharArray() : null);
                     }
-                    
+
                     if (this.keyStorePass != null) {
                         sslConfig.keyStore(keyStore, this.keyStorePass);
                     } else {
@@ -125,7 +127,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
                     throw ROOT_LOGGER.failedToLoadKeyStore(e.getMessage(), e);
                 }
             }
-            
+
             if (this.trustStorePath != null && !this.trustStorePath.trim().isEmpty()) {
                 try {
                     KeyStore trustStore = KeyStore.getInstance("JKS");
@@ -144,7 +146,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
 
             vaultConnector = new VaultConnector(this.hostAddress, token, this.namespace, sslConfig, true, sslContext);
             vaultConnector.configure();
-            
+
             initialized = true;
         } catch (IOException e) {
             throw ROOT_LOGGER.failedToInitializeVaultCredentialStore(e);
@@ -173,13 +175,13 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         if (credential == null) {
             throw ROOT_LOGGER.credentialCannotBeNull();
         }
-        
+
         // Parse credentialAlias in format "path.key"
         String[] aliasSplit = credentialAlias.split("\\.");
         if (aliasSplit.length != 2) {
             throw ROOT_LOGGER.credentialAliasInvalidFormat(credentialAlias);
         }
-        
+
         try {
             final char[] chars = credential.castAndApply(PasswordCredential.class, c -> c.getPassword().castAndApply(ClearPassword.class, ClearPassword::getPassword));
             if (chars == null) {
@@ -202,7 +204,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         if (credentialAlias == null || credentialAlias.trim().isEmpty()) {
             throw ROOT_LOGGER.credentialAliasRequired();
         }
-        
+
         // Parse credentialAlias in format "path.key"
         String[] aliasSplit = credentialAlias.split("\\.");
         if (aliasSplit.length != 2) {
@@ -216,7 +218,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         if (credentialType.isInstance(cached)) {
             return credentialType.cast(cached);
         }
-        
+
         try {
             CredentialSource credentialSource = new VaultCredentialSource(vaultConnector, aliasSplit[0], aliasSplit[1]);
             PasswordCredential credential = credentialSource.getCredential(PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null);
@@ -240,13 +242,13 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
         if (credentialAlias == null || credentialAlias.trim().isEmpty()) {
             throw ROOT_LOGGER.credentialAliasRequired();
         }
-        
+
         // Parse credentialAlias in format "path.key"
         String[] aliasSplit = credentialAlias.split("\\.");
         if (aliasSplit.length != 2) {
             throw ROOT_LOGGER.credentialAliasInvalidFormat(credentialAlias);
         }
-        
+
         try {
             vaultConnector.removeSecret(aliasSplit[0], aliasSplit[1]);
             synchronized (credentialCache) {

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreExtension.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreExtension.java
@@ -4,11 +4,12 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import org.wildfly.security.credential.store.CredentialStoreException;
-import org.wildfly.security.credential.store.CredentialStoreExtension;
+import java.util.Set;
 
 import javax.net.ssl.SSLContext;
-import java.util.Set;
+
+import org.wildfly.security.credential.store.CredentialStoreException;
+import org.wildfly.security.credential.store.CredentialStoreExtension;
 
 /**
  * Extension API for Hashicorp Vault credential store. Exposes only store-specific operations

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreExtension.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreExtension.java
@@ -5,7 +5,6 @@
 package org.wildfly.security.hashicorp.vault;
 
 import java.util.Set;
-import java.util.function.Predicate;
 
 import javax.net.ssl.SSLContext;
 
@@ -19,15 +18,6 @@ import org.wildfly.security.credential.store.CredentialStoreExtension;
 public interface HashicorpVaultCredentialStoreExtension extends CredentialStoreExtension {
 
     void setSslContext(SSLContext sslContext);
-
-    /**
-     * Set a predicate to determine if KV v1 should be used for a given secret engine path.
-     * This allows fallback to KV v1 for specific paths while maintaining KV v2 as the default.
-     *
-     * @param kvV1FallbackPredicate predicate that returns true if the given root path should use KV v1.
-     *                              If null, a default predicate that always returns false will be used (KV v2 for all paths).
-     */
-    void setKvV1FallbackPredicate(Predicate<String> kvV1FallbackPredicate);
 
     /**
      * Get aliases from a specific path in Vault.

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreExtension.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreExtension.java
@@ -5,6 +5,7 @@
 package org.wildfly.security.hashicorp.vault;
 
 import java.util.Set;
+import java.util.function.Predicate;
 
 import javax.net.ssl.SSLContext;
 
@@ -18,6 +19,15 @@ import org.wildfly.security.credential.store.CredentialStoreExtension;
 public interface HashicorpVaultCredentialStoreExtension extends CredentialStoreExtension {
 
     void setSslContext(SSLContext sslContext);
+
+    /**
+     * Set a predicate to determine if KV v1 should be used for a given secret engine path.
+     * This allows fallback to KV v1 for specific paths while maintaining KV v2 as the default.
+     *
+     * @param kvV1FallbackPredicate predicate that returns true if the given root path should use KV v1.
+     *                              If null, a default predicate that always returns false will be used (KV v2 for all paths).
+     */
+    void setKvV1FallbackPredicate(Predicate<String> kvV1FallbackPredicate);
 
     /**
      * Get aliases from a specific path in Vault.

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreProvider.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreProvider.java
@@ -4,11 +4,11 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import org.kohsuke.MetaInfServices;
-import org.wildfly.security.WildFlyElytronBaseProvider;
-
 import java.security.Provider;
 import java.util.Collections;
+
+import org.kohsuke.MetaInfServices;
+import org.wildfly.security.WildFlyElytronBaseProvider;
 
 @MetaInfServices(Provider.class)
 public class HashicorpVaultCredentialStoreProvider extends WildFlyElytronBaseProvider {
@@ -21,7 +21,7 @@ public class HashicorpVaultCredentialStoreProvider extends WildFlyElytronBasePro
      */
     public HashicorpVaultCredentialStoreProvider() {
         super("WildFlyElytronHashicorpVaultProvider", "1.0", "WildFly Elytron HashiCorp Vault CredentialStore Provider");
-        putService(new Service(this, "CredentialStore", "HashicorpVaultCredentialStore", 
+        putService(new Service(this, "CredentialStore", "HashicorpVaultCredentialStore",
                 "org.wildfly.security.hashicorp.vault.HashicorpVaultCredentialStore",
                 Collections.emptyList(), Collections.emptyMap()));
     }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/KeyPathResolver.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/KeyPathResolver.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger.ROOT_LOGGER;
+
+import java.util.Map;
+
+/**
+ * Resolves key paths within Vault secret data.
+ *
+ * <p>Supports two modes of key path resolution:
+ * <ul>
+ *   <li><b>Simple key lookup:</b> When the key path contains no {@code /} separator,
+ *       performs a direct lookup in the data map. This supports keys with dots in their names.</li>
+ *   <li><b>Nested JSON traversal:</b> When the key path contains {@code /} separators,
+ *       traverses nested maps using each segment as a key. Dots within segments are preserved
+ *       as part of the key name.</li>
+ * </ul>
+ *
+ * <p>Examples:
+ * <pre>
+ * Map<String, Object> data = Map.of(
+ *     "password", "secret123",
+ *     "db.host", "localhost",
+ *     "database", Map.of(
+ *         "host", "prod.db.com",
+ *         "credentials", Map.of(
+ *             "user", "admin",
+ *             "pass", "secret"
+ *         )
+ *     ),
+ *     "my.app", Map.of(
+ *         "config.key", "value123"
+ *     )
+ * );
+ *
+ * // Simple key lookups (no / in key path)
+ * resolveKeyPath(data, "password")           → "secret123"
+ * resolveKeyPath(data, "db.host")            → "localhost"  (dots in key name)
+ *
+ * // Nested JSON traversal (with / in key path)
+ * resolveKeyPath(data, "database/host")                    → "prod.db.com"
+ * resolveKeyPath(data, "database/credentials/pass")        → "secret"
+ * resolveKeyPath(data, "my.app/config.key")                → "value123"  (dots in segment)
+ * </pre>
+ */
+class KeyPathResolver {
+
+    /**
+     * Extract value from Vault secret data using key path.
+     *
+     * <p>If the key path contains no {@code /} separator, performs a simple lookup
+     * in the data map (supporting dots in key names). If the key path contains
+     * {@code /} separators, traverses nested maps using each segment as a key.
+     *
+     * @param data the secret data map from Vault
+     * @param keyPath the key path from alias (after ? delimiter, already URL-decoded)
+     * @return the extracted value as a string, or {@code null} if not found
+     * @throws IllegalArgumentException if keyPath is null or empty
+     */
+    public static String resolveKeyPath(Map<String, Object> data, String keyPath) {
+        if (keyPath == null || keyPath.isEmpty()) {
+            throw ROOT_LOGGER.keyPathCannotBeNullOrEmpty();
+        }
+
+        if (data == null) {
+            return null;
+        }
+
+        // Check if key path contains / (nested path)
+        if (!keyPath.contains("/")) {
+            // Simple key - direct lookup (supports dots in key name)
+            Object value = data.get(keyPath);
+            return value != null ? value.toString() : null;
+        }
+
+        // Nested path - traverse using /
+        String[] segments = keyPath.split("/");
+        Object current = data;
+
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i];
+
+            // Validate segment is not empty
+            if (segment.isEmpty()) {
+                throw ROOT_LOGGER.keyPathContainsEmptySegment(keyPath);
+            }
+
+            if (!(current instanceof Map)) {
+                // Can't traverse further - not a map
+                return null;
+            }
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> currentMap = (Map<String, Object>) current;
+
+            // Look up this segment (segment can contain dots)
+            current = currentMap.get(segment);
+
+            if (current == null) {
+                return null;
+            }
+
+            // If this is the last segment, return the value
+            if (i == segments.length - 1) {
+                return current.toString();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/wildfly/security/hashicorp/vault/KeyPathResolver.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/KeyPathResolver.java
@@ -8,6 +8,8 @@ import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger
 
 import java.util.Map;
 
+import org.wildfly.security.credential.store.CredentialStoreException;
+
 /**
  * Resolves key paths within Vault secret data.
  *
@@ -59,9 +61,9 @@ class KeyPathResolver {
      * @param data the secret data map from Vault
      * @param keyPath the key path from alias (after ? delimiter, already URL-decoded)
      * @return the extracted value as a string, or {@code null} if not found
-     * @throws IllegalArgumentException if keyPath is null or empty
+     * @throws CredentialStoreException if keyPath is null or empty
      */
-    public static String resolveKeyPath(Map<String, Object> data, String keyPath) {
+    public static String resolveKeyPath(Map<String, Object> data, String keyPath) throws CredentialStoreException {
         if (keyPath == null || keyPath.isEmpty()) {
             throw ROOT_LOGGER.keyPathCannotBeNullOrEmpty();
         }
@@ -111,5 +113,121 @@ class KeyPathResolver {
         }
 
         return null;
+    }
+
+    /**
+     * Set a value in Vault secret data using key path.
+     * Creates nested maps as needed for nested paths.
+     *
+     * @param data the secret data map to modify
+     * @param keyPath the key path (after ? delimiter, already URL-decoded)
+     * @param value the value to set
+     * @throws CredentialStoreException if keyPath is null or empty
+     */
+    @SuppressWarnings("unchecked")
+    public static void setNestedValue(Map<String, Object> data, String keyPath, String value) throws CredentialStoreException {
+        if (keyPath == null || keyPath.isEmpty()) {
+            throw ROOT_LOGGER.keyPathCannotBeNullOrEmpty();
+        }
+        if (data == null) {
+            throw new IllegalArgumentException("Data map cannot be null");
+        }
+
+        // Check if key path contains / (nested path)
+        if (!keyPath.contains("/")) {
+            // Simple key - direct set
+            data.put(keyPath, value);
+            return;
+        }
+
+        // Nested path - traverse and create maps as needed
+        String[] segments = keyPath.split("/");
+        Map<String, Object> current = data;
+
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i];
+
+            // Validate segment is not empty
+            if (segment.isEmpty()) {
+                throw ROOT_LOGGER.keyPathContainsEmptySegment(keyPath);
+            }
+
+            // If this is the last segment, set the value
+            if (i == segments.length - 1) {
+                current.put(segment, value);
+                return;
+            }
+
+            // Not the last segment - need to traverse or create nested map
+            Object next = current.get(segment);
+            if (next == null) {
+                // Create new nested map
+                Map<String, Object> newMap = new java.util.HashMap<>();
+                current.put(segment, newMap);
+                current = newMap;
+            } else if (next instanceof Map) {
+                // Traverse into existing map
+                current = (Map<String, Object>) next;
+            } else {
+                // Existing value is not a map - replace it with a map
+                Map<String, Object> newMap = new java.util.HashMap<>();
+                current.put(segment, newMap);
+                current = newMap;
+            }
+        }
+    }
+
+    /**
+     * Remove a value from Vault secret data using key path.
+     * For nested paths, removes the leaf value but preserves parent maps.
+     *
+     * @param data the secret data map to modify
+     * @param keyPath the key path (after ? delimiter, already URL-decoded)
+     * @return true if a value was removed, false if the key path didn't exist
+     * @throws CredentialStoreException if keyPath is null or empty
+     */
+    @SuppressWarnings("unchecked")
+    public static boolean removeNestedValue(Map<String, Object> data, String keyPath) throws CredentialStoreException {
+        if (keyPath == null || keyPath.isEmpty()) {
+            throw ROOT_LOGGER.keyPathCannotBeNullOrEmpty();
+        }
+        if (data == null) {
+            return false;
+        }
+
+        // Check if key path contains / (nested path)
+        if (!keyPath.contains("/")) {
+            // Simple key - direct removal
+            return data.remove(keyPath) != null;
+        }
+
+        // Nested path - traverse to parent and remove leaf
+        String[] segments = keyPath.split("/");
+        Map<String, Object> current = data;
+
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i];
+
+            // Validate segment is not empty
+            if (segment.isEmpty()) {
+                throw ROOT_LOGGER.keyPathContainsEmptySegment(keyPath);
+            }
+
+            // If this is the last segment, remove it
+            if (i == segments.length - 1) {
+                return current.remove(segment) != null;
+            }
+
+            // Not the last segment - need to traverse
+            Object next = current.get(segment);
+            if (next == null || !(next instanceof Map)) {
+                // Path doesn't exist or can't traverse further
+                return false;
+            }
+
+            current = (Map<String, Object>) next;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/KeyPathResolver.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/KeyPathResolver.java
@@ -69,18 +69,40 @@ class KeyPathResolver {
         }
 
         if (data == null) {
+            ROOT_LOGGER.debugf("Key path '%s' not found - secret data is null", keyPath);
             return null;
         }
+
+        ROOT_LOGGER.debugf("Resolving key path: %s", keyPath);
 
         // Check if key path contains / (nested path)
         if (!keyPath.contains("/")) {
             // Simple key - direct lookup (supports dots in key name)
             Object value = data.get(keyPath);
-            return value != null ? value.toString() : null;
+            if (value == null) {
+                ROOT_LOGGER.debugf("Key path '%s' not found in secret data", keyPath);
+                return null;
+            }
+            if (value instanceof Map) {
+                // Key path is incomplete - points to a nested structure, not a leaf value
+                ROOT_LOGGER.debugf("Key path '%s' points to a nested structure, not a credential value", keyPath);
+                return null;
+            }
+            ROOT_LOGGER.debugf("Key path '%s' resolved successfully", keyPath);
+            return value.toString();
         }
 
         // Nested path - traverse using /
         String[] segments = keyPath.split("/");
+        int nestingLevel = segments.length;
+
+        // Warn about deep nesting (>5 levels)
+        if (nestingLevel > 5) {
+            ROOT_LOGGER.deepKeyPathNesting(keyPath, nestingLevel);
+        }
+
+        ROOT_LOGGER.debugf("Traversing nested key path with %d segments", nestingLevel);
+
         Object current = data;
 
         for (int i = 0; i < segments.length; i++) {
@@ -93,6 +115,7 @@ class KeyPathResolver {
 
             if (!(current instanceof Map)) {
                 // Can't traverse further - not a map
+                ROOT_LOGGER.debugf("Key path '%s' not found - cannot traverse further at segment '%s'", keyPath, segment);
                 return null;
             }
 
@@ -103,11 +126,18 @@ class KeyPathResolver {
             current = currentMap.get(segment);
 
             if (current == null) {
+                ROOT_LOGGER.debugf("Key path '%s' not found - segment '%s' does not exist", keyPath, segment);
                 return null;
             }
 
             // If this is the last segment, return the value
             if (i == segments.length - 1) {
+                if (current instanceof Map) {
+                    // Key path is incomplete - points to a nested structure, not a leaf value
+                    ROOT_LOGGER.debugf("Key path '%s' points to a nested structure, not a credential value", keyPath);
+                    return null;
+                }
+                ROOT_LOGGER.debugf("Key path '%s' resolved successfully", keyPath);
                 return current.toString();
             }
         }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -39,8 +39,9 @@ class VaultAlias {
     private final String secretPath;
     private final String keyPath;
 
+
     /**
-     * Private constructor - use {@link #parse(String)} or {@link #parse(String, String, String)} to create instances.
+     * Private constructor - use factory methods to create instances.
      *
      * @param engineType the engine type (KVv1 or KVv2)
      * @param mountPath the mount path
@@ -52,6 +53,48 @@ class VaultAlias {
         this.mountPath = mountPath;
         this.secretPath = secretPath;
         this.keyPath = keyPath;
+    }
+
+    /**
+     * Create a VaultAlias directly from components without parsing.
+     * This method validates the engine type but does not perform URL encoding -
+     * components should already be in their decoded form.
+     *
+     * @param engineType the engine type (KVv1 or KVv2)
+     * @param mountPath the mount path
+     * @param secretPath the secret path
+     * @param keyPath the key path
+     * @return a new VaultAlias instance
+     * @throws CredentialStoreException if the engine type is invalid or any required component is null/empty
+     */
+    static VaultAlias create(String engineType, String mountPath, String secretPath, String keyPath) throws CredentialStoreException {
+        // Validate required parameters
+        if (engineType == null || engineType.isEmpty()) {
+            throw ROOT_LOGGER.engineTypeCannotBeEmpty("direct creation");
+        }
+        if (mountPath == null || mountPath.isEmpty()) {
+            throw ROOT_LOGGER.mountPathCannotBeEmpty("direct creation");
+        }
+        if (secretPath == null || secretPath.isEmpty()) {
+            throw ROOT_LOGGER.secretPathCannotBeEmpty("direct creation");
+        }
+        if (keyPath == null || keyPath.isEmpty()) {
+            throw ROOT_LOGGER.keyPathCannotBeEmpty("direct creation");
+        }
+
+        // Validate engine type
+        if (!engineType.equals("KVv1") && !engineType.equals("KVv2")) {
+            throw ROOT_LOGGER.invalidEngineType(engineType);
+        }
+
+        // Validate key path doesn't contain empty segments (if using nested path syntax)
+        if (keyPath.contains("/")) {
+            if (keyPath.startsWith("/") || keyPath.endsWith("/") || keyPath.contains("//")) {
+                throw ROOT_LOGGER.keyPathContainsEmptySegment(keyPath);
+            }
+        }
+
+        return new VaultAlias(engineType, mountPath, secretPath, keyPath);
     }
 
     /**
@@ -335,6 +378,8 @@ class VaultAlias {
     public String getKeyPath() {
         return keyPath;
     }
+
+
 
     @Override
     public String toString() {

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -34,15 +34,24 @@ import org.wildfly.security.credential.store.CredentialStoreException;
  */
 class VaultAlias {
 
-    private String engineType;
-    private String mountPath;
-    private String secretPath;
-    private String keyPath;
+    private final String engineType;
+    private final String mountPath;
+    private final String secretPath;
+    private final String keyPath;
 
     /**
      * Private constructor - use {@link #parse(String)} or {@link #parse(String, String, String)} to create instances.
+     *
+     * @param engineType the engine type (KVv1 or KVv2)
+     * @param mountPath the mount path
+     * @param secretPath the secret path
+     * @param keyPath the key path
      */
-    private VaultAlias() {
+    private VaultAlias(String engineType, String mountPath, String secretPath, String keyPath) {
+        this.engineType = engineType;
+        this.mountPath = mountPath;
+        this.secretPath = secretPath;
+        this.keyPath = keyPath;
     }
 
     /**
@@ -107,29 +116,27 @@ class VaultAlias {
         }
 
         // Parse as legacy format and log deprecation warning
-        VaultAlias result = new VaultAlias();
-        result.engineType = defaultEngineType;
-        result.mountPath = defaultMountPath;
-        result.secretPath = alias.substring(0, lastDot);
-        result.keyPath = alias.substring(lastDot + 1);
+        String secretPath = alias.substring(0, lastDot);
+        String keyPath = alias.substring(lastDot + 1);
 
         // Validate
-        if (result.secretPath.isEmpty()) {
+        if (secretPath.isEmpty()) {
             throw ROOT_LOGGER.secretPathCannotBeEmpty(alias);
         }
-        if (result.keyPath.isEmpty()) {
+        if (keyPath.isEmpty()) {
             throw ROOT_LOGGER.keyPathCannotBeEmpty(alias);
         }
 
         // URL-decode segments (legacy format may also have URL encoding)
-        result.secretPath = urlDecode(result.secretPath);
-        result.keyPath = urlDecode(result.keyPath);
+        secretPath = urlDecode(secretPath);
+        keyPath = urlDecode(keyPath);
 
         // Log deprecation warning with equivalent new format
         String newFormat = convertLegacyToNewFormat(alias);
         ROOT_LOGGER.legacyAliasFormatDeprecated(alias, newFormat);
 
-        return result;
+        // Create immutable instance
+        return new VaultAlias(defaultEngineType, defaultMountPath, secretPath, keyPath);
     }
 
     /**
@@ -164,9 +171,11 @@ class VaultAlias {
             throw ROOT_LOGGER.aliasCannotBeNullOrEmpty();
         }
 
-        VaultAlias result = new VaultAlias();
-        result.engineType = defaultEngineType;
-        result.mountPath = defaultMountPath;
+        // Use local variables to collect parsed values
+        String engineType = defaultEngineType;
+        String mountPath = defaultMountPath;
+        String secretPath;
+        String keyPath;
 
         String remaining = alias;
 
@@ -176,8 +185,8 @@ class VaultAlias {
             if (nextDelim == -1) {
                 throw ROOT_LOGGER.invalidEngineSpecificationMissingDelimiter(alias);
             }
-            result.engineType = remaining.substring(7, nextDelim);
-            if (result.engineType.isEmpty()) {
+            engineType = remaining.substring(7, nextDelim);
+            if (engineType.isEmpty()) {
                 throw ROOT_LOGGER.engineTypeCannotBeEmpty(alias);
             }
             remaining = remaining.substring(nextDelim);
@@ -189,8 +198,8 @@ class VaultAlias {
             if (hashPos == -1) {
                 throw ROOT_LOGGER.missingHashDelimiterAfterMountPath(alias);
             }
-            result.mountPath = remaining.substring(1, hashPos);
-            if (result.mountPath.isEmpty()) {
+            mountPath = remaining.substring(1, hashPos);
+            if (mountPath.isEmpty()) {
                 throw ROOT_LOGGER.mountPathCannotBeEmpty(alias);
             }
             remaining = remaining.substring(hashPos);
@@ -208,33 +217,42 @@ class VaultAlias {
             throw ROOT_LOGGER.missingQuestionDelimiterBeforeKeyPath(alias);
         }
 
-        result.secretPath = remaining.substring(0, questionPos);
-        result.keyPath = remaining.substring(questionPos + 1);
+        secretPath = remaining.substring(0, questionPos);
+        keyPath = remaining.substring(questionPos + 1);
 
         // 5. Validate
-        if (result.secretPath.isEmpty()) {
+        if (secretPath.isEmpty()) {
             throw ROOT_LOGGER.secretPathCannotBeEmpty(alias);
         }
-        if (result.keyPath.isEmpty()) {
+        if (keyPath.isEmpty()) {
             throw ROOT_LOGGER.keyPathCannotBeEmpty(alias);
         }
 
         // 6. URL-decode each segment separately
         // CRITICAL: Decode AFTER splitting to avoid double-encoding issues
-        result.engineType = urlDecode(result.engineType);
-        result.mountPath = urlDecode(result.mountPath);
-        result.secretPath = urlDecode(result.secretPath);
-        result.keyPath = urlDecode(result.keyPath);
+        engineType = urlDecode(engineType);
+        mountPath = urlDecode(mountPath);
+        secretPath = urlDecode(secretPath);
+        keyPath = urlDecode(keyPath);
 
-        // 7. Validate engine type after URL decoding (in case someone URL-encodes the engine type)
-        if (!result.engineType.equals("KVv1") && !result.engineType.equals("KVv2")) {
-            throw ROOT_LOGGER.invalidEngineType(result.engineType);
+        // 7. Validate key path doesn't contain empty segments (if using nested path syntax)
+        if (keyPath.contains("/")) {
+            // Check for empty segments: leading /, trailing /, or //
+            if (keyPath.startsWith("/") || keyPath.endsWith("/") || keyPath.contains("//")) {
+                throw ROOT_LOGGER.keyPathContainsEmptySegment(keyPath);
+            }
+        }
+
+        // 8. Validate engine type after URL decoding (in case someone URL-encodes the engine type)
+        if (!engineType.equals("KVv1") && !engineType.equals("KVv2")) {
+            throw ROOT_LOGGER.invalidEngineType(engineType);
         }
 
         // Note: The decoded values will be passed to Vault client library,
         // which will handle URL encoding for the actual API calls
 
-        return result;
+        // Create immutable instance with all validated values
+        return new VaultAlias(engineType, mountPath, secretPath, keyPath);
     }
 
     /**

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -6,13 +6,12 @@ package org.wildfly.security.hashicorp.vault;
 
 import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger.ROOT_LOGGER;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-
 import org.wildfly.security.credential.store.CredentialStoreException;
 
 /**
  * Represents a parsed Vault alias in the new format.
+ *
+ * <p>Extends {@link VaultPath} to add key path support for complete alias specification.
  *
  * <p>Format: {@code [engine=TYPE][@mount-path]#secret-path?key-path}
  *
@@ -32,26 +31,20 @@ import org.wildfly.security.credential.store.CredentialStoreException;
  *   <li>{@code #myapp/database?database/credentials/password} - Nested JSON path</li>
  * </ul>
  */
-class VaultAlias {
+class VaultAlias extends VaultPath {
 
-    private final String engineType;
-    private final String mountPath;
-    private final String secretPath;
     private final String keyPath;
 
-
     /**
-     * Private constructor - use factory methods to create instances.
+     * Package-private constructor - use factory methods or VaultPath.parse() to create instances.
      *
      * @param engineType the engine type (KVv1 or KVv2)
      * @param mountPath the mount path
      * @param secretPath the secret path
      * @param keyPath the key path
      */
-    private VaultAlias(String engineType, String mountPath, String secretPath, String keyPath) {
-        this.engineType = engineType;
-        this.mountPath = mountPath;
-        this.secretPath = secretPath;
+    VaultAlias(String engineType, String mountPath, String secretPath, String keyPath) {
+        super(engineType, mountPath, secretPath);
         this.keyPath = keyPath;
     }
 
@@ -105,99 +98,7 @@ class VaultAlias {
      * @throws CredentialStoreException if the alias format is invalid
      */
     public static VaultAlias parse(String alias) throws CredentialStoreException {
-        return parse(alias, "KVv2", "secret");
-    }
-
-    /**
-     * Parse a vault alias string with legacy format support.
-     * <p>
-     * This method first checks if the alias uses the new format (contains {@code ?}, {@code #}, {@code @},
-     * or starts with {@code engine=}). If so, it delegates to {@link #parse(String, String, String)}.
-     * <p>
-     * If the alias appears to be in legacy format (no new format indicators), behavior depends on the
-     * {@code supportLegacyFormat} parameter:
-     * <ul>
-     *   <li>If {@code true}: Parse as legacy format (split on last dot) and log deprecation warning</li>
-     *   <li>If {@code false}: Throw exception with migration guidance</li>
-     * </ul>
-     * <p>
-     * Legacy format: {@code secret-path.key} where the last dot separates secret path from key.
-     *
-     * @param alias the alias string to parse
-     * @param defaultEngineType the default engine type to use if not specified in alias
-     * @param defaultMountPath the default mount path to use if not specified in alias
-     * @param supportLegacyFormat whether to support legacy format
-     * @return the parsed VaultAlias
-     * @throws CredentialStoreException if the alias format is invalid or legacy format is not supported
-     */
-    public static VaultAlias parseWithLegacySupport(String alias, String defaultEngineType,
-                                                     String defaultMountPath, boolean supportLegacyFormat) throws CredentialStoreException {
-        if (alias == null || alias.isEmpty()) {
-            throw ROOT_LOGGER.aliasCannotBeNullOrEmpty();
-        }
-
-        // Check if it's new format (contains ?, #, @, or starts with engine=)
-        if (alias.contains("?") || alias.contains("#") ||
-            alias.contains("@") || alias.startsWith("engine=")) {
-            // New format - use standard parsing
-            return parse(alias, defaultEngineType, defaultMountPath);
-        }
-
-        // No new format indicators found - check if it's valid legacy format
-        int lastDot = alias.lastIndexOf('.');
-        if (lastDot == -1) {
-            // No dot found - not valid legacy format either
-            // This is an invalid alias format
-            throw ROOT_LOGGER.invalidAliasFormat(alias);
-        }
-
-        // Valid legacy format detected (has a dot)
-        if (!supportLegacyFormat) {
-            // Legacy format not supported - throw error with migration guidance
-            String newFormat = convertLegacyToNewFormat(alias);
-            throw ROOT_LOGGER.legacyAliasFormatNotSupported(alias, newFormat);
-        }
-
-        // Parse as legacy format and log deprecation warning
-        String secretPath = alias.substring(0, lastDot);
-        String keyPath = alias.substring(lastDot + 1);
-
-        // Validate
-        if (secretPath.isEmpty()) {
-            throw ROOT_LOGGER.secretPathCannotBeEmpty(alias);
-        }
-        if (keyPath.isEmpty()) {
-            throw ROOT_LOGGER.keyPathCannotBeEmpty(alias);
-        }
-
-        // URL-decode segments (legacy format may also have URL encoding)
-        secretPath = urlDecode(secretPath);
-        keyPath = urlDecode(keyPath);
-
-        // Log deprecation warning with equivalent new format
-        String newFormat = convertLegacyToNewFormat(alias);
-        ROOT_LOGGER.legacyAliasFormatDeprecated(alias, newFormat);
-
-        // Create immutable instance
-        return new VaultAlias(defaultEngineType, defaultMountPath, secretPath, keyPath);
-    }
-
-    /**
-     * Convert a legacy format alias to the equivalent new format.
-     * <p>
-     * Legacy format: {@code secret-path.key} (split on last dot)
-     * New format: {@code secret-path?key} (# is optional when no engine= or @ prefix)
-     * <p>
-     * Note: This method assumes the alias has already been validated to contain a dot.
-     *
-     * @param legacyAlias the legacy format alias (must contain a dot)
-     * @return the equivalent new format alias
-     */
-    private static String convertLegacyToNewFormat(String legacyAlias) {
-        int lastDot = legacyAlias.lastIndexOf('.');
-        String secretPath = legacyAlias.substring(0, lastDot);
-        String keyPath = legacyAlias.substring(lastDot + 1);
-        return secretPath + "?" + keyPath;
+        return parse(alias, "KVv2", "secret", false);
     }
 
     /**
@@ -210,168 +111,27 @@ class VaultAlias {
      * @throws CredentialStoreException if the alias format is invalid
      */
     public static VaultAlias parse(String alias, String defaultEngineType, String defaultMountPath) throws CredentialStoreException {
-        if (alias == null || alias.isEmpty()) {
-            throw ROOT_LOGGER.aliasCannotBeNullOrEmpty();
-        }
-
-        ROOT_LOGGER.debugf("Parsing alias: %s", alias);
-
-        // Use local variables to collect parsed values
-        String engineType = defaultEngineType;
-        String mountPath = defaultMountPath;
-        String secretPath;
-        String keyPath;
-
-        // Use index-based parsing to reduce GC pressure from intermediate String objects
-        int pos = 0;
-        final int length = alias.length();
-
-        // 1. Extract engine type (optional, starts with "engine=")
-        if (alias.startsWith("engine=")) {
-            pos = 7; // Skip "engine="
-            int nextDelim = findNextDelimiter(alias, pos, '@', '#');
-            if (nextDelim == -1) {
-                throw ROOT_LOGGER.invalidEngineSpecificationMissingDelimiter(alias);
-            }
-            engineType = alias.substring(pos, nextDelim);
-            if (engineType.isEmpty()) {
-                throw ROOT_LOGGER.engineTypeCannotBeEmpty(alias);
-            }
-            pos = nextDelim;
-        }
-
-        // 2. Extract mount path (optional, starts with @)
-        if (pos < length && alias.charAt(pos) == '@') {
-            pos++; // Skip @
-            int hashPos = alias.indexOf('#', pos);
-            if (hashPos == -1) {
-                throw ROOT_LOGGER.missingHashDelimiterAfterMountPath(alias);
-            }
-            mountPath = alias.substring(pos, hashPos);
-            if (mountPath.isEmpty()) {
-                throw ROOT_LOGGER.mountPathCannotBeEmpty(alias);
-            }
-            pos = hashPos;
-        }
-
-        // 3. Extract secret path (optional # prefix)
-        // The # is required only after @ mount path, otherwise it's optional
-        if (pos < length && alias.charAt(pos) == '#') {
-            pos++; // Skip # if present
-        }
-
-        // 4. Find key delimiter (?)
-        int questionPos = alias.indexOf('?', pos);
-        if (questionPos == -1) {
-            throw ROOT_LOGGER.missingQuestionDelimiterBeforeKeyPath(alias);
-        }
-
-        secretPath = alias.substring(pos, questionPos);
-        keyPath = alias.substring(questionPos + 1);
-
-        // 5. Validate
-        if (secretPath.isEmpty()) {
-            throw ROOT_LOGGER.secretPathCannotBeEmpty(alias);
-        }
-        if (keyPath.isEmpty()) {
-            throw ROOT_LOGGER.keyPathCannotBeEmpty(alias);
-        }
-
-        // 6. URL-decode each segment separately
-        // CRITICAL: Decode AFTER splitting to avoid double-encoding issues
-        engineType = urlDecode(engineType);
-        mountPath = urlDecode(mountPath);
-        secretPath = urlDecode(secretPath);
-        keyPath = urlDecode(keyPath);
-
-        // 7. Validate key path doesn't contain empty segments (if using nested path syntax)
-        if (keyPath.contains("/")) {
-            // Check for empty segments: leading /, trailing /, or //
-            if (keyPath.startsWith("/") || keyPath.endsWith("/") || keyPath.contains("//")) {
-                throw ROOT_LOGGER.keyPathContainsEmptySegment(keyPath);
-            }
-        }
-
-        // 8. Validate engine type after URL decoding (in case someone URL-encodes the engine type)
-        if (!engineType.equals("KVv1") && !engineType.equals("KVv2")) {
-            throw ROOT_LOGGER.invalidEngineType(engineType);
-        }
-
-        // Note: The decoded values will be passed to Vault client library,
-        // which will handle URL encoding for the actual API calls
-
-        ROOT_LOGGER.debugf("Parsed alias: engine=%s, mount=%s, secret=%s, key=%s",
-                          engineType, mountPath, secretPath, keyPath);
-
-        // Create immutable instance with all validated values
-        return new VaultAlias(engineType, mountPath, secretPath, keyPath);
+        return parse(alias, defaultEngineType, defaultMountPath, false);
     }
 
     /**
-     * Find the position of the next delimiter character in the string.
+     * Parse a vault alias string with specified defaults and optional legacy format support.
      *
-     * @param s the string to search
-     * @param start the starting position
-     * @param delims the delimiter characters to search for
-     * @return the position of the first delimiter found, or -1 if none found
-     */
-    private static int findNextDelimiter(String s, int start, char... delims) {
-        int minPos = -1;
-        for (char delim : delims) {
-            int pos = s.indexOf(delim, start);
-            if (pos != -1 && (minPos == -1 || pos < minPos)) {
-                minPos = pos;
-            }
-        }
-        return minPos;
-    }
-
-    /**
-     * URL-decode a string using UTF-8 encoding.
+     * <p>Format: {@code [engine=TYPE][@mount-path]#secret-path?key-path}
      *
-     * @param s the string to decode
-     * @return the decoded string, or the original string if decoding fails
-     */
-    private static String urlDecode(String s) {
-        if (s == null) {
-            return null;
-        }
-        try {
-            return URLDecoder.decode(s, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            // UTF-8 should always be supported, but if not, return as-is
-            return s;
-        } catch (IllegalArgumentException e) {
-            // Invalid URL encoding - return as-is
-            return s;
-        }
-    }
-
-    /**
-     * Get the engine type (e.g., "KVv1", "KVv2").
+     * <p>When {@code supportLegacyFormat} is true, also accepts legacy format: {@code secret-path.key}
+     * where the last dot separates secret path from key. Legacy format triggers a deprecation warning.
      *
-     * @return the engine type
+     * @param alias the alias string to parse
+     * @param defaultEngineType the default engine type to use if not specified in alias
+     * @param defaultMountPath the default mount path to use if not specified in alias
+     * @param supportLegacyFormat whether to support legacy {@code secret.key} format
+     * @return the parsed VaultAlias
+     * @throws CredentialStoreException if the alias format is invalid or legacy format is not supported
      */
-    public String getEngineType() {
-        return engineType;
-    }
-
-    /**
-     * Get the mount path (e.g., "secret", "team/backend").
-     *
-     * @return the mount path
-     */
-    public String getMountPath() {
-        return mountPath;
-    }
-
-    /**
-     * Get the secret path (e.g., "myapp/database", "my.app.config").
-     *
-     * @return the secret path
-     */
-    public String getSecretPath() {
-        return secretPath;
+    public static VaultAlias parse(String alias, String defaultEngineType, String defaultMountPath,
+                                   boolean supportLegacyFormat) throws CredentialStoreException {
+        return VaultPath.parse(alias, defaultEngineType, defaultMountPath, supportLegacyFormat, true, VaultAlias.class);
     }
 
     /**
@@ -390,7 +150,7 @@ class VaultAlias {
      * @throws CredentialStoreException if the engine type is not a valid KV version
      */
     public int getKvVersion() throws CredentialStoreException {
-        return engineTypeToVersion(engineType);
+        return engineTypeToVersion(getEngineType());
     }
 
     /**
@@ -421,9 +181,9 @@ class VaultAlias {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("VaultAlias{");
-        sb.append("engineType='").append(engineType).append('\'');
-        sb.append(", mountPath='").append(mountPath).append('\'');
-        sb.append(", secretPath='").append(secretPath).append('\'');
+        sb.append("engineType='").append(getEngineType()).append('\'');
+        sb.append(", mountPath='").append(getMountPath()).append('\'');
+        sb.append(", secretPath='").append(getSecretPath()).append('\'');
         sb.append(", keyPath='").append(keyPath).append('\'');
         sb.append('}');
         return sb.toString();

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -222,48 +222,52 @@ class VaultAlias {
         String secretPath;
         String keyPath;
 
-        String remaining = alias;
+        // Use index-based parsing to reduce GC pressure from intermediate String objects
+        int pos = 0;
+        final int length = alias.length();
 
         // 1. Extract engine type (optional, starts with "engine=")
-        if (remaining.startsWith("engine=")) {
-            int nextDelim = findNextDelimiter(remaining, 7, '@', '#');
+        if (alias.startsWith("engine=")) {
+            pos = 7; // Skip "engine="
+            int nextDelim = findNextDelimiter(alias, pos, '@', '#');
             if (nextDelim == -1) {
                 throw ROOT_LOGGER.invalidEngineSpecificationMissingDelimiter(alias);
             }
-            engineType = remaining.substring(7, nextDelim);
+            engineType = alias.substring(pos, nextDelim);
             if (engineType.isEmpty()) {
                 throw ROOT_LOGGER.engineTypeCannotBeEmpty(alias);
             }
-            remaining = remaining.substring(nextDelim);
+            pos = nextDelim;
         }
 
         // 2. Extract mount path (optional, starts with @)
-        if (remaining.startsWith("@")) {
-            int hashPos = remaining.indexOf('#');
+        if (pos < length && alias.charAt(pos) == '@') {
+            pos++; // Skip @
+            int hashPos = alias.indexOf('#', pos);
             if (hashPos == -1) {
                 throw ROOT_LOGGER.missingHashDelimiterAfterMountPath(alias);
             }
-            mountPath = remaining.substring(1, hashPos);
+            mountPath = alias.substring(pos, hashPos);
             if (mountPath.isEmpty()) {
                 throw ROOT_LOGGER.mountPathCannotBeEmpty(alias);
             }
-            remaining = remaining.substring(hashPos);
+            pos = hashPos;
         }
 
         // 3. Extract secret path (optional # prefix)
         // The # is required only after @ mount path, otherwise it's optional
-        if (remaining.startsWith("#")) {
-            remaining = remaining.substring(1); // Skip # if present
+        if (pos < length && alias.charAt(pos) == '#') {
+            pos++; // Skip # if present
         }
 
         // 4. Find key delimiter (?)
-        int questionPos = remaining.indexOf('?');
+        int questionPos = alias.indexOf('?', pos);
         if (questionPos == -1) {
             throw ROOT_LOGGER.missingQuestionDelimiterBeforeKeyPath(alias);
         }
 
-        secretPath = remaining.substring(0, questionPos);
-        keyPath = remaining.substring(questionPos + 1);
+        secretPath = alias.substring(pos, questionPos);
+        keyPath = alias.substring(questionPos + 1);
 
         // 5. Validate
         if (secretPath.isEmpty()) {

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -171,6 +171,8 @@ class VaultAlias {
             throw ROOT_LOGGER.aliasCannotBeNullOrEmpty();
         }
 
+        ROOT_LOGGER.debugf("Parsing alias: %s", alias);
+
         // Use local variables to collect parsed values
         String engineType = defaultEngineType;
         String mountPath = defaultMountPath;
@@ -250,6 +252,9 @@ class VaultAlias {
 
         // Note: The decoded values will be passed to Vault client library,
         // which will handle URL encoding for the actual API calls
+
+        ROOT_LOGGER.debugf("Parsed alias: engine=%s, mount=%s, secret=%s, key=%s",
+                          engineType, mountPath, secretPath, keyPath);
 
         // Create immutable instance with all validated values
         return new VaultAlias(engineType, mountPath, secretPath, keyPath);

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -9,6 +9,8 @@ import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
+import org.wildfly.security.credential.store.CredentialStoreException;
+
 /**
  * Represents a parsed Vault alias in the new format.
  *
@@ -48,9 +50,9 @@ class VaultAlias {
      *
      * @param alias the alias string to parse
      * @return the parsed VaultAlias
-     * @throws IllegalArgumentException if the alias format is invalid
+     * @throws CredentialStoreException if the alias format is invalid
      */
-    public static VaultAlias parse(String alias) {
+    public static VaultAlias parse(String alias) throws CredentialStoreException {
         return parse(alias, "KVv2", "secret");
     }
 
@@ -74,10 +76,10 @@ class VaultAlias {
      * @param defaultMountPath the default mount path to use if not specified in alias
      * @param supportLegacyFormat whether to support legacy format
      * @return the parsed VaultAlias
-     * @throws IllegalArgumentException if the alias format is invalid or legacy format is not supported
+     * @throws CredentialStoreException if the alias format is invalid or legacy format is not supported
      */
     public static VaultAlias parseWithLegacySupport(String alias, String defaultEngineType,
-                                                     String defaultMountPath, boolean supportLegacyFormat) {
+                                                     String defaultMountPath, boolean supportLegacyFormat) throws CredentialStoreException {
         if (alias == null || alias.isEmpty()) {
             throw ROOT_LOGGER.aliasCannotBeNullOrEmpty();
         }
@@ -105,7 +107,6 @@ class VaultAlias {
         }
 
         // Parse as legacy format and log deprecation warning
-
         VaultAlias result = new VaultAlias();
         result.engineType = defaultEngineType;
         result.mountPath = defaultMountPath;
@@ -156,9 +157,9 @@ class VaultAlias {
      * @param defaultEngineType the default engine type to use if not specified in alias
      * @param defaultMountPath the default mount path to use if not specified in alias
      * @return the parsed VaultAlias
-     * @throws IllegalArgumentException if the alias format is invalid
+     * @throws CredentialStoreException if the alias format is invalid
      */
-    public static VaultAlias parse(String alias, String defaultEngineType, String defaultMountPath) {
+    public static VaultAlias parse(String alias, String defaultEngineType, String defaultMountPath) throws CredentialStoreException {
         if (alias == null || alias.isEmpty()) {
             throw ROOT_LOGGER.aliasCannotBeNullOrEmpty();
         }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger.ROOT_LOGGER;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+/**
+ * Represents a parsed Vault alias in the new format.
+ *
+ * <p>Format: {@code [engine=TYPE][@mount-path]#secret-path?key-path}
+ *
+ * <p>Components:
+ * <ul>
+ *   <li>{@code engine=TYPE} - Optional engine type specification (e.g., {@code engine=KVv1}, {@code engine=KVv2})</li>
+ *   <li>{@code @mount-path} - Optional mount path (e.g., {@code @secret}, {@code @team/backend})</li>
+ *   <li>{@code #secret-path} - Required secret path (e.g., {@code #myapp/database})</li>
+ *   <li>{@code ?key-path} - Required key path (e.g., {@code ?password}, {@code ?database/credentials/password})</li>
+ * </ul>
+ *
+ * <p>Examples:
+ * <ul>
+ *   <li>{@code #myapp/database?password} - Simple key with defaults</li>
+ *   <li>{@code engine=KVv1@secret-v1#myapp?password} - Explicit engine and mount</li>
+ *   <li>{@code #my.app.config?db.host} - Dots in secret path and key name</li>
+ *   <li>{@code #myapp/database?database/credentials/password} - Nested JSON path</li>
+ * </ul>
+ */
+class VaultAlias {
+
+    private String engineType;
+    private String mountPath;
+    private String secretPath;
+    private String keyPath;
+
+    /**
+     * Private constructor - use {@link #parse(String)} or {@link #parse(String, String, String)} to create instances.
+     */
+    private VaultAlias() {
+    }
+
+    /**
+     * Parse a vault alias string using default engine type and mount path.
+     *
+     * @param alias the alias string to parse
+     * @return the parsed VaultAlias
+     * @throws IllegalArgumentException if the alias format is invalid
+     */
+    public static VaultAlias parse(String alias) {
+        return parse(alias, "KVv2", "secret");
+    }
+
+    /**
+     * Parse a vault alias string with specified defaults for engine type and mount path.
+     *
+     * @param alias the alias string to parse
+     * @param defaultEngineType the default engine type to use if not specified in alias
+     * @param defaultMountPath the default mount path to use if not specified in alias
+     * @return the parsed VaultAlias
+     * @throws IllegalArgumentException if the alias format is invalid
+     */
+    public static VaultAlias parse(String alias, String defaultEngineType, String defaultMountPath) {
+        if (alias == null || alias.isEmpty()) {
+            throw ROOT_LOGGER.aliasCannotBeNullOrEmpty();
+        }
+
+        VaultAlias result = new VaultAlias();
+        result.engineType = defaultEngineType;
+        result.mountPath = defaultMountPath;
+
+        String remaining = alias;
+
+        // 1. Extract engine type (optional, starts with "engine=")
+        if (remaining.startsWith("engine=")) {
+            int nextDelim = findNextDelimiter(remaining, 7, '@', '#');
+            if (nextDelim == -1) {
+                throw ROOT_LOGGER.invalidEngineSpecificationMissingDelimiter(alias);
+            }
+            result.engineType = remaining.substring(7, nextDelim);
+            if (result.engineType.isEmpty()) {
+                throw ROOT_LOGGER.engineTypeCannotBeEmpty(alias);
+            }
+            remaining = remaining.substring(nextDelim);
+        }
+
+        // 2. Extract mount path (optional, starts with @)
+        if (remaining.startsWith("@")) {
+            int hashPos = remaining.indexOf('#');
+            if (hashPos == -1) {
+                throw ROOT_LOGGER.missingHashDelimiterAfterMountPath(alias);
+            }
+            result.mountPath = remaining.substring(1, hashPos);
+            if (result.mountPath.isEmpty()) {
+                throw ROOT_LOGGER.mountPathCannotBeEmpty(alias);
+            }
+            remaining = remaining.substring(hashPos);
+        }
+
+        // 3. Extract secret path (required, starts with #)
+        if (!remaining.startsWith("#")) {
+            throw ROOT_LOGGER.secretPathMustStartWithHash(alias);
+        }
+        remaining = remaining.substring(1); // Skip #
+
+        // 4. Find key delimiter (?)
+        int questionPos = remaining.indexOf('?');
+        if (questionPos == -1) {
+            throw ROOT_LOGGER.missingQuestionDelimiterBeforeKeyPath(alias);
+        }
+
+        result.secretPath = remaining.substring(0, questionPos);
+        result.keyPath = remaining.substring(questionPos + 1);
+
+        // 5. Validate
+        if (result.secretPath.isEmpty()) {
+            throw ROOT_LOGGER.secretPathCannotBeEmpty(alias);
+        }
+        if (result.keyPath.isEmpty()) {
+            throw ROOT_LOGGER.keyPathCannotBeEmpty(alias);
+        }
+
+        // 6. URL-decode each segment separately
+        // CRITICAL: Decode AFTER splitting to avoid double-encoding issues
+        result.engineType = urlDecode(result.engineType);
+        result.mountPath = urlDecode(result.mountPath);
+        result.secretPath = urlDecode(result.secretPath);
+        result.keyPath = urlDecode(result.keyPath);
+
+        // Note: The decoded values will be passed to Vault client library,
+        // which will handle URL encoding for the actual API calls
+
+        return result;
+    }
+
+    /**
+     * Find the position of the next delimiter character in the string.
+     *
+     * @param s the string to search
+     * @param start the starting position
+     * @param delims the delimiter characters to search for
+     * @return the position of the first delimiter found, or -1 if none found
+     */
+    private static int findNextDelimiter(String s, int start, char... delims) {
+        int minPos = -1;
+        for (char delim : delims) {
+            int pos = s.indexOf(delim, start);
+            if (pos != -1 && (minPos == -1 || pos < minPos)) {
+                minPos = pos;
+            }
+        }
+        return minPos;
+    }
+
+    /**
+     * URL-decode a string using UTF-8 encoding.
+     *
+     * @param s the string to decode
+     * @return the decoded string, or the original string if decoding fails
+     */
+    private static String urlDecode(String s) {
+        if (s == null) {
+            return null;
+        }
+        try {
+            return URLDecoder.decode(s, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // UTF-8 should always be supported, but if not, return as-is
+            return s;
+        } catch (IllegalArgumentException e) {
+            // Invalid URL encoding - return as-is
+            return s;
+        }
+    }
+
+    /**
+     * Get the engine type (e.g., "KVv1", "KVv2").
+     *
+     * @return the engine type
+     */
+    public String getEngineType() {
+        return engineType;
+    }
+
+    /**
+     * Get the mount path (e.g., "secret", "team/backend").
+     *
+     * @return the mount path
+     */
+    public String getMountPath() {
+        return mountPath;
+    }
+
+    /**
+     * Get the secret path (e.g., "myapp/database", "my.app.config").
+     *
+     * @return the secret path
+     */
+    public String getSecretPath() {
+        return secretPath;
+    }
+
+    /**
+     * Get the key path (e.g., "password", "database/credentials/password").
+     *
+     * @return the key path
+     */
+    public String getKeyPath() {
+        return keyPath;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("VaultAlias{");
+        sb.append("engineType='").append(engineType).append('\'');
+        sb.append(", mountPath='").append(mountPath).append('\'');
+        sb.append(", secretPath='").append(secretPath).append('\'');
+        sb.append(", keyPath='").append(keyPath).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -225,6 +225,11 @@ class VaultAlias {
         result.secretPath = urlDecode(result.secretPath);
         result.keyPath = urlDecode(result.keyPath);
 
+        // 7. Validate engine type after URL decoding (in case someone URL-encodes the engine type)
+        if (!result.engineType.equals("KVv1") && !result.engineType.equals("KVv2")) {
+            throw ROOT_LOGGER.invalidEngineType(result.engineType);
+        }
+
         // Note: The decoded values will be passed to Vault client library,
         // which will handle URL encoding for the actual API calls
 

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -250,11 +250,11 @@ class VaultAlias {
             remaining = remaining.substring(hashPos);
         }
 
-        // 3. Extract secret path (required, starts with #)
-        if (!remaining.startsWith("#")) {
-            throw ROOT_LOGGER.secretPathMustStartWithHash(alias);
+        // 3. Extract secret path (optional # prefix)
+        // The # is required only after @ mount path, otherwise it's optional
+        if (remaining.startsWith("#")) {
+            remaining = remaining.substring(1); // Skip # if present
         }
-        remaining = remaining.substring(1); // Skip #
 
         // 4. Find key delimiter (?)
         int questionPos = remaining.indexOf('?');

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -55,6 +55,101 @@ class VaultAlias {
     }
 
     /**
+     * Parse a vault alias string with legacy format support.
+     * <p>
+     * This method first checks if the alias uses the new format (contains {@code ?}, {@code #}, {@code @},
+     * or starts with {@code engine=}). If so, it delegates to {@link #parse(String, String, String)}.
+     * <p>
+     * If the alias appears to be in legacy format (no new format indicators), behavior depends on the
+     * {@code supportLegacyFormat} parameter:
+     * <ul>
+     *   <li>If {@code true}: Parse as legacy format (split on last dot) and log deprecation warning</li>
+     *   <li>If {@code false}: Throw exception with migration guidance</li>
+     * </ul>
+     * <p>
+     * Legacy format: {@code secret-path.key} where the last dot separates secret path from key.
+     *
+     * @param alias the alias string to parse
+     * @param defaultEngineType the default engine type to use if not specified in alias
+     * @param defaultMountPath the default mount path to use if not specified in alias
+     * @param supportLegacyFormat whether to support legacy format
+     * @return the parsed VaultAlias
+     * @throws IllegalArgumentException if the alias format is invalid or legacy format is not supported
+     */
+    public static VaultAlias parseWithLegacySupport(String alias, String defaultEngineType,
+                                                     String defaultMountPath, boolean supportLegacyFormat) {
+        if (alias == null || alias.isEmpty()) {
+            throw ROOT_LOGGER.aliasCannotBeNullOrEmpty();
+        }
+
+        // Check if it's new format (contains ?, #, @, or starts with engine=)
+        if (alias.contains("?") || alias.contains("#") ||
+            alias.contains("@") || alias.startsWith("engine=")) {
+            // New format - use standard parsing
+            return parse(alias, defaultEngineType, defaultMountPath);
+        }
+
+        // No new format indicators found - check if it's valid legacy format
+        int lastDot = alias.lastIndexOf('.');
+        if (lastDot == -1) {
+            // No dot found - not valid legacy format either
+            // This is an invalid alias format
+            throw ROOT_LOGGER.invalidAliasFormat(alias);
+        }
+
+        // Valid legacy format detected (has a dot)
+        if (!supportLegacyFormat) {
+            // Legacy format not supported - throw error with migration guidance
+            String newFormat = convertLegacyToNewFormat(alias);
+            throw ROOT_LOGGER.legacyAliasFormatNotSupported(alias, newFormat);
+        }
+
+        // Parse as legacy format and log deprecation warning
+
+        VaultAlias result = new VaultAlias();
+        result.engineType = defaultEngineType;
+        result.mountPath = defaultMountPath;
+        result.secretPath = alias.substring(0, lastDot);
+        result.keyPath = alias.substring(lastDot + 1);
+
+        // Validate
+        if (result.secretPath.isEmpty()) {
+            throw ROOT_LOGGER.secretPathCannotBeEmpty(alias);
+        }
+        if (result.keyPath.isEmpty()) {
+            throw ROOT_LOGGER.keyPathCannotBeEmpty(alias);
+        }
+
+        // URL-decode segments (legacy format may also have URL encoding)
+        result.secretPath = urlDecode(result.secretPath);
+        result.keyPath = urlDecode(result.keyPath);
+
+        // Log deprecation warning with equivalent new format
+        String newFormat = convertLegacyToNewFormat(alias);
+        ROOT_LOGGER.legacyAliasFormatDeprecated(alias, newFormat);
+
+        return result;
+    }
+
+    /**
+     * Convert a legacy format alias to the equivalent new format.
+     * <p>
+     * Legacy format: {@code secret-path.key} (split on last dot)
+     * New format: {@code secret-path?key} (# is optional when no engine= or @ prefix)
+     * <p>
+     * Note: This method assumes the alias has already been validated to contain a dot.
+     *
+     * @param legacyAlias the legacy format alias (must contain a dot)
+     * @return the equivalent new format alias
+     */
+    private static String convertLegacyToNewFormat(String legacyAlias) {
+        int lastDot = legacyAlias.lastIndexOf('.');
+        String secretPath = legacyAlias.substring(0, lastDot);
+        String keyPath = legacyAlias.substring(lastDot + 1);
+        return secretPath + "?" + keyPath;
+    }
+
+    /**
      * Parse a vault alias string with specified defaults for engine type and mount path.
      *
      * @param alias the alias string to parse

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -379,6 +379,38 @@ class VaultAlias {
         return keyPath;
     }
 
+    /**
+     * Convert the engine type string to a KV version number.
+     *
+     * @return 1 for KVv1, 2 for KVv2
+     * @throws CredentialStoreException if the engine type is not a valid KV version
+     */
+    public int getKvVersion() throws CredentialStoreException {
+        return engineTypeToVersion(engineType);
+    }
+
+    /**
+     * Convert an engine type string to a KV version number.
+     * This is a utility method that can be used without creating a VaultAlias instance.
+     *
+     * @param engineType the engine type string (e.g., "KVv1", "KVv2")
+     * @return 1 for KVv1, 2 for KVv2
+     * @throws CredentialStoreException if the engine type is not a valid KV version
+     */
+    static int engineTypeToVersion(String engineType) throws CredentialStoreException {
+        if (engineType == null) {
+            throw ROOT_LOGGER.invalidEngineType("null");
+        }
+        switch (engineType) {
+            case "KVv1":
+                return 1;
+            case "KVv2":
+                return 2;
+            default:
+                throw ROOT_LOGGER.invalidEngineType(engineType);
+        }
+    }
+
 
 
     @Override

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
@@ -340,7 +340,7 @@ public class VaultConnector {
 
             // Create a Vault instance for listing
             // Use the mount path segment count for proper /metadata/ insertion
-            int kvVersion = "KVv2".equals(engineType) ? 2 : 1;
+            int kvVersion = VaultAlias.engineTypeToVersion(engineType);
             int segmentCount = countMountPathSegments(mountPath);
             Vault vault = createVaultInstance(kvVersion, segmentCount);
             LogicalResponse response = vault.logical().list(listPath);

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import javax.net.ssl.SSLContext;
 
@@ -33,68 +34,61 @@ import io.github.jopenlibs.vault.response.LogicalResponse;
  */
 class VaultConnector {
 
+    private static final Predicate<String> DEFAULT_KV_V1_FALLBACK_PREDICATE = path -> false;
+
     private final String vaultUrl;
     private final String token;
     private final String namespace;
     private final SslConfig sslConfig;
-    private Vault vault;
+    private Vault vaultV2;  // Default Vault instance configured for KV v2
+    private Vault vaultV1;  // Vault instance configured for KV v1 (created lazily if needed)
     private final SSLContext sslContext;
+    private final Predicate<String> kvV1FallbackPredicate;
 
     private JwtConfig jwtConfig;
 
     public VaultConnector(String vaultUrl, String token, String namespace, SslConfig sslConfig, boolean sslVerify) {
-        this(vaultUrl, token, namespace, sslConfig, sslVerify, null);
+        this(vaultUrl, token, namespace, sslConfig, sslVerify, null, DEFAULT_KV_V1_FALLBACK_PREDICATE);
     }
 
     public VaultConnector(String vaultUrl, String token, String namespace, SslConfig sslConfig, boolean sslVerify, SSLContext sslContext) {
+        this(vaultUrl, token, namespace, sslConfig, sslVerify, sslContext, DEFAULT_KV_V1_FALLBACK_PREDICATE);
+    }
+
+    public VaultConnector(String vaultUrl, String token, String namespace, SslConfig sslConfig, boolean sslVerify, SSLContext sslContext, Predicate<String> kvV1FallbackPredicate) {
         this.vaultUrl = vaultUrl;
         this.token = token;
         this.namespace = namespace;
         this.sslConfig = sslConfig;
         this.sslContext = sslContext;
+        this.kvV1FallbackPredicate = kvV1FallbackPredicate != null ? kvV1FallbackPredicate : DEFAULT_KV_V1_FALLBACK_PREDICATE;
     }
 
     public VaultConnector(String vaultUrl, JwtConfig jwtConfig, String namespace, SslConfig sslConfig) {
-        this(vaultUrl, jwtConfig, namespace, sslConfig, null);
+        this(vaultUrl, jwtConfig, namespace, sslConfig, null, DEFAULT_KV_V1_FALLBACK_PREDICATE);
     }
 
     public VaultConnector(String vaultUrl, JwtConfig jwtConfig, String namespace, SslConfig sslConfig, SSLContext sslContext) {
+        this(vaultUrl, jwtConfig, namespace, sslConfig, sslContext, DEFAULT_KV_V1_FALLBACK_PREDICATE);
+    }
+
+    public VaultConnector(String vaultUrl, JwtConfig jwtConfig, String namespace, SslConfig sslConfig, SSLContext sslContext, Predicate<String> kvV1FallbackPredicate) {
         this.vaultUrl = vaultUrl;
         this.token = null;
         this.namespace = namespace;
         this.sslConfig = sslConfig;
         this.jwtConfig = jwtConfig;
         this.sslContext = sslContext;
+        this.kvV1FallbackPredicate = kvV1FallbackPredicate != null ? kvV1FallbackPredicate : DEFAULT_KV_V1_FALLBACK_PREDICATE;
     }
 
     public void configure() throws VaultException {
-        try {
+        // Both Vault instances will be created lazily on first use
+        // This avoids unnecessary overhead if only one version is needed
+        this.vaultV1 = null;
+        this.vaultV2 = null;
 
-            VaultConfig config = new VaultConfig()
-                    .sslConfig(this.sslConfig)
-                    .address(this.vaultUrl);
-            HttpClient httpClient;
-
-            if (sslContext != null) {
-                httpClient = HttpClient.newBuilder()
-                        .sslContext(sslContext)
-                        .build();
-                config.httpClient(httpClient);
-            }
-
-            if (this.namespace != null && !this.namespace.isEmpty()) {
-                config.nameSpace(this.namespace);
-            }
-
-            final LoginContext loginContext = new LoginContext(token, jwtConfig,
-                    Vault.create(config.build()));
-            this.vault = tryLoginWithFallback(loginContext, config);
-
-            ROOT_LOGGER.vaultConfigurationSuccessful(this.vaultUrl);
-        } catch (VaultException e) {
-            ROOT_LOGGER.vaultConnectorConfigurationFailed(this.vaultUrl, e);
-            throw e;
-        }
+        ROOT_LOGGER.vaultConfigurationSuccessful(this.vaultUrl);
     }
 
     /**
@@ -146,6 +140,69 @@ class VaultConnector {
     }
 
     /**
+     * Get the appropriate Vault instance based on the path and KV version predicate.
+     * Creates Vault instances lazily on first use.
+     */
+    private synchronized Vault getVaultForPath(String path) throws VaultException {
+        String rootPath = extractRootPath(path);
+
+        if (kvV1FallbackPredicate.test(rootPath)) {
+            // Need KV v1 - create instance if not already created
+            if (vaultV1 == null) {
+                vaultV1 = createVaultInstance(1);
+            }
+            return vaultV1;
+        }
+
+        // Default to KV v2 - create instance if not already created
+        if (vaultV2 == null) {
+            vaultV2 = createVaultInstance(2);
+        }
+        return vaultV2;
+    }
+
+    /**
+     * Create a Vault instance configured for the specified KV engine version.
+     */
+    private Vault createVaultInstance(int kvVersion) throws VaultException {
+        VaultConfig config = new VaultConfig()
+                .sslConfig(this.sslConfig)
+                .address(this.vaultUrl)
+                .engineVersion(kvVersion);
+
+        HttpClient httpClient;
+        if (sslContext != null) {
+            httpClient = HttpClient.newBuilder()
+                    .sslContext(sslContext)
+                    .build();
+            config.httpClient(httpClient);
+        }
+
+        if (this.namespace != null && !this.namespace.isEmpty()) {
+            config.nameSpace(this.namespace);
+        }
+
+        final LoginContext loginContext = new LoginContext(token, jwtConfig,
+                Vault.create(config.build()));
+        return tryLoginWithFallback(loginContext, config);
+    }
+
+    /**
+     * Extract the root path (mount point) from a full path.
+     * For example: "secret/myapp/db" -> "secret"
+     */
+    private String extractRootPath(String path) {
+        if (path == null || path.isEmpty()) {
+            return "";
+        }
+        int slashIndex = path.indexOf('/');
+        if (slashIndex == -1) {
+            return path;
+        }
+        return path.substring(0, slashIndex);
+    }
+
+    /**
      * Retrieve a secret from Vault
      */
     public String getSecret(String path, String key) throws VaultException {
@@ -156,8 +213,11 @@ class VaultConnector {
             throw new VaultException(ROOT_LOGGER.vaultKeyCannotBeNullOrEmpty());
         }
 
-        // Fetch from Vault
-        LogicalResponse response = this.vault.logical().read(path);
+        // Get the appropriate Vault instance for this path
+        Vault vault = getVaultForPath(path);
+
+        // Fetch from Vault - the library handles path adjustments internally
+        LogicalResponse response = vault.logical().read(path);
         int responseStatus = response.getRestResponse().getStatus();
         if (responseStatus == 200) {
             Map<String, String> data = response.getData();
@@ -195,9 +255,12 @@ class VaultConnector {
             throw new VaultException(ROOT_LOGGER.vaultValueCannotBeNull());
         }
 
+        // Get the appropriate Vault instance for this path
+        Vault vault = getVaultForPath(path);
+
         Map<String, Object> nameValuePairs = new HashMap<>();
         // Read existing path to preserve other keys if those exist
-        LogicalResponse readResponse = this.vault.logical().read(path);
+        LogicalResponse readResponse = vault.logical().read(path);
         int readStatus = readResponse.getRestResponse().getStatus();
         if (readStatus == 200) {
             Map<String, String> existingData = readResponse.getData();
@@ -207,7 +270,7 @@ class VaultConnector {
         }
 
         nameValuePairs.put(key, value);
-        LogicalResponse response = this.vault.logical().write(path, nameValuePairs);
+        LogicalResponse response = vault.logical().write(path, nameValuePairs);
         int responseStatus = response.getRestResponse().getStatus();
         if (responseStatus == 200 || responseStatus == 204) {
             ROOT_LOGGER.vaultStoredSecret(path, this.vaultUrl);
@@ -231,9 +294,12 @@ class VaultConnector {
             throw new VaultException(ROOT_LOGGER.vaultKeyCannotBeNullOrEmpty());
         }
 
+        // Get the appropriate Vault instance for this path
+        Vault vault = getVaultForPath(path);
+
         // Read existing path to preserve other keys at the same path
         Map<String, Object> nameValuePairs = new HashMap<>();
-        LogicalResponse readResponse = this.vault.logical().read(path);
+        LogicalResponse readResponse = vault.logical().read(path);
         int readStatus = readResponse.getRestResponse().getStatus();
         if (readStatus == 200) {
             Map<String, String> existingData = readResponse.getData();
@@ -248,7 +314,7 @@ class VaultConnector {
         }
         nameValuePairs.remove(key);
         if (nameValuePairs.isEmpty()) {
-            LogicalResponse deleteResponse = this.vault.logical().delete(path);
+            LogicalResponse deleteResponse = vault.logical().delete(path);
             int deleteStatus = deleteResponse.getRestResponse().getStatus();
             if (deleteStatus == 200 || deleteStatus == 204) {
                 ROOT_LOGGER.vaultDeletedSecretPath(path);
@@ -260,7 +326,7 @@ class VaultConnector {
             throw new VaultException(ROOT_LOGGER.vaultFailedToDeleteSecretHttp(path, deleteStatus));
         } else {
             // Write back the remaining keys
-            LogicalResponse writeResponse = this.vault.logical().write(path, nameValuePairs);
+            LogicalResponse writeResponse = vault.logical().write(path, nameValuePairs);
             int writeStatus = writeResponse.getRestResponse().getStatus();
             if (writeStatus == 200 || writeStatus == 204) {
                 ROOT_LOGGER.vaultRemovedKeyFromPath(key, path);
@@ -277,7 +343,8 @@ class VaultConnector {
      * Get all keys for a specific path
      */
     public Set<String> getKeysForPath(String path) throws VaultException {
-        LogicalResponse response = this.vault.logical().read(path);
+        Vault vault = getVaultForPath(path);
+        LogicalResponse response = vault.logical().read(path);
         int responseStatus = response.getRestResponse().getStatus();
         if (responseStatus == 200) {
             Map<String, String> data = response.getData();
@@ -299,11 +366,15 @@ class VaultConnector {
         if (path == null || path.trim().isEmpty()) {
             throw new VaultException(ROOT_LOGGER.vaultPathCannotBeNullOrEmpty());
         }
+
+        // Get the appropriate Vault instance for this path
+        Vault vault = getVaultForPath(path);
+
         // vault expects trailing slash with list operation
         String listPath = path.endsWith("/") ? path : path + "/";
 
         try {
-            LogicalResponse response = this.vault.logical().list(listPath);
+            LogicalResponse response = vault.logical().list(listPath);
             int responseStatus = response.getRestResponse().getStatus();
             if (responseStatus == 200) {
                 List<String> keys = response.getListData();
@@ -322,4 +393,5 @@ class VaultConnector {
             throw new VaultException(ROOT_LOGGER.vaultUnexpectedListSubpathsFormat(path, e.getMessage()));
         }
     }
+
 }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
@@ -14,18 +14,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.Vault;
-import io.github.jopenlibs.vault.VaultConfig;
-import io.github.jopenlibs.vault.VaultException;
-import io.github.jopenlibs.vault.response.LogicalResponse;
+import javax.net.ssl.SSLContext;
+
 import org.wildfly.security.hashicorp.vault.loginstrategy.ClientCertificateLoginStrategy;
 import org.wildfly.security.hashicorp.vault.loginstrategy.JwtLoginStrategy;
 import org.wildfly.security.hashicorp.vault.loginstrategy.LoginContext;
 import org.wildfly.security.hashicorp.vault.loginstrategy.TokenLoginStrategy;
 import org.wildfly.security.hashicorp.vault.loginstrategy.VaultLoginStrategy;
 
-import javax.net.ssl.SSLContext;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.VaultConfig;
+import io.github.jopenlibs.vault.VaultException;
+import io.github.jopenlibs.vault.response.LogicalResponse;
 
 /**
  * Vault Connector
@@ -300,7 +301,7 @@ public class VaultConnector {
         }
         // vault expects trailing slash with list operation
         String listPath = path.endsWith("/") ? path : path + "/";
-        
+
         try {
             LogicalResponse response = this.vault.logical().list(listPath);
             int responseStatus = response.getRestResponse().getStatus();

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
@@ -31,7 +31,7 @@ import io.github.jopenlibs.vault.response.LogicalResponse;
 /**
  * Vault Connector
  */
-class VaultConnector {
+public class VaultConnector {
 
     private static final Predicate<String> DEFAULT_KV_V1_FALLBACK_PREDICATE = path -> false;
 
@@ -72,13 +72,11 @@ class VaultConnector {
         this.namespace = namespace;
         this.sslConfig = sslConfig;
 
-        // Always create HttpClient for connection pooling efficiency
-        // HttpClient in Java 11+ uses connection pooling by default
-        HttpClient.Builder builder = HttpClient.newBuilder();
         if (sslContext != null) {
-            builder.sslContext(sslContext);
+            this.httpClient = HttpClient.newBuilder().sslContext(sslContext).build();
+        } else {
+            this.httpClient = null;
         }
-        this.httpClient = builder.build();
     }
 
     public VaultConnector(String vaultUrl, JwtConfig jwtConfig, String namespace, SslConfig sslConfig) {
@@ -96,13 +94,11 @@ class VaultConnector {
         this.sslConfig = sslConfig;
         this.jwtConfig = jwtConfig;
 
-        // Always create HttpClient for connection pooling efficiency
-        // HttpClient in Java 11+ uses connection pooling by default
-        HttpClient.Builder builder = HttpClient.newBuilder();
         if (sslContext != null) {
-            builder.sslContext(sslContext);
+            this.httpClient = HttpClient.newBuilder().sslContext(sslContext).build();
+        } else {
+            this.httpClient = null;
         }
-        this.httpClient = builder.build();
     }
 
     public void configure() {
@@ -189,7 +185,7 @@ class VaultConnector {
      * @param alias the parsed vault alias containing engine type and path information
      * @return the appropriate Vault instance for the specified engine type and mount path
      */
-    private synchronized Vault getVaultForAlias(VaultAlias alias) {
+    private synchronized Vault getVaultForAlias(VaultAlias alias) throws CredentialStoreException {
         String engineType = alias.getEngineType();
         String mountPath = alias.getMountPath();
 
@@ -210,14 +206,23 @@ class VaultConnector {
             cacheKey = "KVv2-" + segmentCount;
         }
 
-        return vaultInstanceCache.computeIfAbsent(cacheKey,
-            k -> {
-                try {
-                    return createVaultInstance(kvVersion, segmentCount);
-                } catch (VaultException | CredentialStoreException e) {
-                    throw new RuntimeException(e);
-                }
-            });
+        try {
+            return vaultInstanceCache.computeIfAbsent(cacheKey,
+                k -> {
+                    try {
+                        return createVaultInstance(kvVersion, segmentCount);
+                    } catch (VaultException | CredentialStoreException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        } catch (RuntimeException e) {
+            // Unwrap CredentialStoreException if it was wrapped in RuntimeException
+            Throwable cause = e.getCause();
+            if (cause instanceof CredentialStoreException) {
+                throw (CredentialStoreException) cause;
+            }
+            throw e;
+        }
     }
 
 
@@ -234,11 +239,19 @@ class VaultConnector {
         VaultConfig config = new VaultConfig()
                 .sslConfig(this.sslConfig)
                 .address(this.vaultUrl)
-                .engineVersion(kvVersion)
-                .prefixPathDepth(prefixPathDepth);
+                .engineVersion(kvVersion);
 
-        // Always use the shared HttpClient for connection pooling
-        config.httpClient(httpClient);
+        // Only set prefixPathDepth if > 1 (library default is 1 for single-segment paths)
+        if (prefixPathDepth > 1) {
+            config.prefixPathDepth(prefixPathDepth);
+        }
+
+        // Use the shared HttpClient only when it has been configured with a custom SSLContext.
+        // Otherwise, let the Vault library create its own client from the SslConfig
+        // (which may include PEM trust certificates that the default HttpClient doesn't know about).
+        if (httpClient != null) {
+            config.httpClient(httpClient);
+        }
 
         if (this.namespace != null && !this.namespace.isEmpty()) {
             config.nameSpace(this.namespace);
@@ -270,7 +283,41 @@ class VaultConnector {
             secretPath = secretPath.substring(1);
         }
 
+        // URL-encode path segments to handle special characters (spaces, etc.)
+        // The Vault library doesn't properly encode path components
+        mountPath = urlEncodePath(mountPath);
+        secretPath = urlEncodePath(secretPath);
+
         return mountPath + "/" + secretPath;
+    }
+
+    /**
+     * URL-encode a path while preserving path separators (/).
+     * Encodes each segment separately to avoid encoding the slashes.
+     */
+    private String urlEncodePath(String path) {
+        if (path == null || path.isEmpty()) {
+            return path;
+        }
+
+        String[] segments = path.split("/", -1);
+        StringBuilder encoded = new StringBuilder();
+
+        for (int i = 0; i < segments.length; i++) {
+            if (i > 0) {
+                encoded.append("/");
+            }
+            try {
+                // Encode each segment, preserving structure
+                encoded.append(java.net.URLEncoder.encode(segments[i], "UTF-8")
+                    .replace("+", "%20")); // Use %20 for spaces instead of +
+            } catch (java.io.UnsupportedEncodingException e) {
+                // UTF-8 is always supported
+                throw new RuntimeException(e);
+            }
+        }
+
+        return encoded.toString();
     }
 
     /**
@@ -282,6 +329,66 @@ class VaultConnector {
      * @return map of all key-value pairs in the secret, or null if secret not found
      * @throws CredentialStoreException if retrieval fails
      */
+    /**
+     * List all secret paths at the given mount and path.
+     *
+     * @param mountPath the mount path (e.g., "secret")
+     * @param secretPath the secret path to list (e.g., "myapp" or "myapp/db")
+     * @param engineType the engine type ("KVv1" or "KVv2")
+     * @return set of subpath names (directories end with "/", secrets don't)
+     * @throws CredentialStoreException if listing fails
+     */
+    public List<String> listSecretsAtPath(String mountPath, String secretPath, String engineType) throws CredentialStoreException {
+        try {
+            // For KV v2, the Vault library automatically adds /metadata/ when listing
+            // So we just pass mount + secret path, and it constructs the full path
+            String listPath;
+            if (secretPath == null || secretPath.isEmpty()) {
+                listPath = mountPath;
+            } else {
+                listPath = mountPath + "/" + secretPath;
+            }
+
+            // Create a Vault instance for listing
+            // Use the mount path segment count for proper /metadata/ insertion
+            int kvVersion = "KVv2".equals(engineType) ? 2 : 1;
+            int segmentCount = countMountPathSegments(mountPath);
+            Vault vault = createVaultInstance(kvVersion, segmentCount);
+            LogicalResponse response = vault.logical().list(listPath);
+            int status = response.getRestResponse().getStatus();
+
+            if (status == 200) {
+                List<String> keys = response.getListData();
+                return keys != null ? keys : new ArrayList<>();
+            } else if (status == 404) {
+                // Path doesn't exist or is empty
+                return new ArrayList<>();
+            } else if (status == 403) {
+                throw ROOT_LOGGER.forbiddenToListSubpathsAtCredentialStorePath(listPath,
+                    new VaultException("HTTP 403 Forbidden"));
+            } else {
+                throw ROOT_LOGGER.couldNotListSecretsAtPath(listPath, status);
+            }
+        } catch (VaultException e) {
+            throw ROOT_LOGGER.couldNotListSecretsAtPath(mountPath + "/" + secretPath, e);
+        }
+    }
+
+    /**
+     * Get all keys (field names) for a secret at the given path.
+     *
+     * @param alias the vault alias specifying the secret location
+     * @return set of key names in the secret
+     * @throws CredentialStoreException if reading fails
+     */
+    public List<String> getKeysForSecret(VaultAlias alias) throws CredentialStoreException {
+        Map<String, Object> secretData = getSecretData(alias);
+        if (secretData == null) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(secretData.keySet());
+    }
+
     public Map<String, Object> getSecretData(VaultAlias alias) throws CredentialStoreException {
         if (alias == null) {
             throw ROOT_LOGGER.vaultAliasCannotBeNull();
@@ -290,10 +397,7 @@ class VaultConnector {
         String path = constructVaultPath(alias);
 
         try {
-            // Get the appropriate Vault instance based on alias engine type
             Vault vault = getVaultForAlias(alias);
-
-            // Fetch from Vault - the library handles path adjustments internally
             LogicalResponse response = vault.logical().read(path);
             int responseStatus = response.getRestResponse().getStatus();
             if (responseStatus == 200) {

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
@@ -31,7 +31,7 @@ import io.github.jopenlibs.vault.response.LogicalResponse;
 /**
  * Vault Connector
  */
-public class VaultConnector {
+class VaultConnector {
 
     private final String vaultUrl;
     private final String token;

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
@@ -9,14 +9,13 @@ import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger
 import java.net.http.HttpClient;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import javax.net.ssl.SSLContext;
 
+import org.wildfly.security.credential.store.CredentialStoreException;
 import org.wildfly.security.hashicorp.vault.loginstrategy.ClientCertificateLoginStrategy;
 import org.wildfly.security.hashicorp.vault.loginstrategy.JwtLoginStrategy;
 import org.wildfly.security.hashicorp.vault.loginstrategy.LoginContext;
@@ -40,12 +39,24 @@ class VaultConnector {
     private final String token;
     private final String namespace;
     private final SslConfig sslConfig;
-    private Vault vaultV2;  // Default Vault instance configured for KV v2
-    private Vault vaultV1;  // Vault instance configured for KV v1 (created lazily if needed)
-    private final SSLContext sslContext;
-    private final Predicate<String> kvV1FallbackPredicate;
+
+    /**
+     * Cached HttpClient instance (created once during initialization).
+     * Reused across all Vault instances for efficient connection pooling.
+     * HttpClient in Java 11+ uses connection pooling by default, so a single
+     * instance can efficiently handle multiple concurrent requests to the same destination.
+     */
+    private final HttpClient httpClient;
 
     private JwtConfig jwtConfig;
+
+    /**
+     * Cache of Vault instances keyed by engine type and mount path segment count.
+     * Key format: "KVv1" or "KVv2-{segmentCount}"
+     * For KV v1, segment count doesn't matter (no /data/ insertion)
+     * For KV v2, we need different instances for different segment counts
+     */
+    private final Map<String, Vault> vaultInstanceCache = new HashMap<>();
 
     public VaultConnector(String vaultUrl, String token, String namespace, SslConfig sslConfig, boolean sslVerify) {
         this(vaultUrl, token, namespace, sslConfig, sslVerify, null, DEFAULT_KV_V1_FALLBACK_PREDICATE);
@@ -60,8 +71,14 @@ class VaultConnector {
         this.token = token;
         this.namespace = namespace;
         this.sslConfig = sslConfig;
-        this.sslContext = sslContext;
-        this.kvV1FallbackPredicate = kvV1FallbackPredicate != null ? kvV1FallbackPredicate : DEFAULT_KV_V1_FALLBACK_PREDICATE;
+
+        // Always create HttpClient for connection pooling efficiency
+        // HttpClient in Java 11+ uses connection pooling by default
+        HttpClient.Builder builder = HttpClient.newBuilder();
+        if (sslContext != null) {
+            builder.sslContext(sslContext);
+        }
+        this.httpClient = builder.build();
     }
 
     public VaultConnector(String vaultUrl, JwtConfig jwtConfig, String namespace, SslConfig sslConfig) {
@@ -78,16 +95,18 @@ class VaultConnector {
         this.namespace = namespace;
         this.sslConfig = sslConfig;
         this.jwtConfig = jwtConfig;
-        this.sslContext = sslContext;
-        this.kvV1FallbackPredicate = kvV1FallbackPredicate != null ? kvV1FallbackPredicate : DEFAULT_KV_V1_FALLBACK_PREDICATE;
+
+        // Always create HttpClient for connection pooling efficiency
+        // HttpClient in Java 11+ uses connection pooling by default
+        HttpClient.Builder builder = HttpClient.newBuilder();
+        if (sslContext != null) {
+            builder.sslContext(sslContext);
+        }
+        this.httpClient = builder.build();
     }
 
-    public void configure() throws VaultException {
-        // Both Vault instances will be created lazily on first use
-        // This avoids unnecessary overhead if only one version is needed
-        this.vaultV1 = null;
-        this.vaultV2 = null;
-
+    public void configure() {
+        // Vault instances will be created lazily on first use and cached
         ROOT_LOGGER.vaultConfigurationSuccessful(this.vaultUrl);
     }
 
@@ -98,9 +117,9 @@ class VaultConnector {
      * @param loginContext current login context
      * @param config initial VaultConfig
      * @return Vault with token configured
-     * @throws VaultException thrown when anything goes wrong, including situation when all methods fail.
+     * @throws CredentialStoreException thrown when all login strategies fail
      */
-    private Vault tryLoginWithFallback(LoginContext loginContext, VaultConfig config) throws VaultException {
+    private Vault tryLoginWithFallback(LoginContext loginContext, VaultConfig config) throws CredentialStoreException {
         for (VaultLoginStrategy strategy : composePossibleLoginStrategiesPrioritized(loginContext)) {
             try {
                 String response = strategy.tryLogin(loginContext);
@@ -117,7 +136,7 @@ class VaultConnector {
             }
         }
 
-        throw new VaultException(ROOT_LOGGER.vaultAllLoginStrategiesFailed());
+        throw ROOT_LOGGER.vaultAllLoginStrategiesFailed();
     }
 
     private List<VaultLoginStrategy> composePossibleLoginStrategiesPrioritized(final LoginContext loginContext) {
@@ -140,43 +159,86 @@ class VaultConnector {
     }
 
     /**
-     * Get the appropriate Vault instance based on the path and KV version predicate.
-     * Creates Vault instances lazily on first use.
+     * Count the number of path segments in a mount path.
+     * For example: "secret" = 1, "team/backend" = 2, "org/team/backend" = 3
+     *
+     * @param mountPath the mount path
+     * @return the number of segments
      */
-    private synchronized Vault getVaultForPath(String path) throws VaultException {
-        String rootPath = extractRootPath(path);
-
-        if (kvV1FallbackPredicate.test(rootPath)) {
-            // Need KV v1 - create instance if not already created
-            if (vaultV1 == null) {
-                vaultV1 = createVaultInstance(1);
+    private int countMountPathSegments(String mountPath) {
+        if (mountPath == null || mountPath.isEmpty()) {
+            return 0;
+        }
+        // Count slashes and add 1
+        int count = 1;
+        for (int i = 0; i < mountPath.length(); i++) {
+            if (mountPath.charAt(i) == '/') {
+                count++;
             }
-            return vaultV1;
         }
-
-        // Default to KV v2 - create instance if not already created
-        if (vaultV2 == null) {
-            vaultV2 = createVaultInstance(2);
-        }
-        return vaultV2;
+        return count;
     }
 
     /**
-     * Create a Vault instance configured for the specified KV engine version.
+     * Get the appropriate Vault instance based on the alias engine type and mount path.
+     * Creates Vault instances lazily on first use and caches them.
+     *
+     * For KV v2, different mount path segment counts require different Vault instances
+     * because the driver needs to know where to insert the /data/ segment.
+     *
+     * @param alias the parsed vault alias containing engine type and path information
+     * @return the appropriate Vault instance for the specified engine type and mount path
      */
-    private Vault createVaultInstance(int kvVersion) throws VaultException {
+    private synchronized Vault getVaultForAlias(VaultAlias alias) {
+        String engineType = alias.getEngineType();
+        String mountPath = alias.getMountPath();
+
+        // Determine KV version and segment count
+        final int kvVersion;
+        final int segmentCount;
+        final String cacheKey;
+
+        if ("KVv1".equals(engineType)) {
+            // KV v1 doesn't use /data/ insertion, so segment count doesn't matter
+            kvVersion = 1;
+            segmentCount = 0; // irrelevant for v1
+            cacheKey = "KVv1";
+        } else {
+            // KV v2 - need to account for mount path segment count
+            kvVersion = 2;
+            segmentCount = countMountPathSegments(mountPath);
+            cacheKey = "KVv2-" + segmentCount;
+        }
+
+        return vaultInstanceCache.computeIfAbsent(cacheKey,
+            k -> {
+                try {
+                    return createVaultInstance(kvVersion, segmentCount);
+                } catch (VaultException | CredentialStoreException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+
+    /**
+     * Create a Vault instance configured for the specified KV engine version and mount path depth.
+     *
+     * @param kvVersion the KV engine version (1 or 2)
+     * @param prefixPathDepth the number of path segments in the mount path (e.g., "secret" = 1, "team/backend" = 2)
+     * @return configured Vault instance
+     * @throws VaultException if Vault library operations fail
+     * @throws CredentialStoreException if login fails
+     */
+    private Vault createVaultInstance(int kvVersion, int prefixPathDepth) throws VaultException, CredentialStoreException {
         VaultConfig config = new VaultConfig()
                 .sslConfig(this.sslConfig)
                 .address(this.vaultUrl)
-                .engineVersion(kvVersion);
+                .engineVersion(kvVersion)
+                .prefixPathDepth(prefixPathDepth);
 
-        HttpClient httpClient;
-        if (sslContext != null) {
-            httpClient = HttpClient.newBuilder()
-                    .sslContext(sslContext)
-                    .build();
-            config.httpClient(httpClient);
-        }
+        // Always use the shared HttpClient for connection pooling
+        config.httpClient(httpClient);
 
         if (this.namespace != null && !this.namespace.isEmpty()) {
             config.nameSpace(this.namespace);
@@ -188,209 +250,210 @@ class VaultConnector {
     }
 
     /**
-     * Extract the root path (mount point) from a full path.
-     * For example: "secret/myapp/db" -> "secret"
+     * Construct the full Vault path from alias components.
+     * Combines mount path and secret path with proper formatting.
+     *
+     * @param alias the parsed vault alias
+     * @return the full path for Vault API calls
      */
-    private String extractRootPath(String path) {
-        if (path == null || path.isEmpty()) {
-            return "";
+    private String constructVaultPath(VaultAlias alias) {
+        String mountPath = alias.getMountPath();
+        String secretPath = alias.getSecretPath();
+
+        // Ensure mount path doesn't end with /
+        if (mountPath.endsWith("/")) {
+            mountPath = mountPath.substring(0, mountPath.length() - 1);
         }
-        int slashIndex = path.indexOf('/');
-        if (slashIndex == -1) {
-            return path;
+
+        // Ensure secret path doesn't start with /
+        if (secretPath.startsWith("/")) {
+            secretPath = secretPath.substring(1);
         }
-        return path.substring(0, slashIndex);
+
+        return mountPath + "/" + secretPath;
     }
 
     /**
-     * Retrieve a secret from Vault
+     * Retrieve full secret data from Vault using the new alias format.
+     * Returns the complete data map for the secret, which can then be
+     * processed using KeyPathResolver to extract specific values.
+     *
+     * @param alias the parsed vault alias containing mount path, secret path, and engine type
+     * @return map of all key-value pairs in the secret, or null if secret not found
+     * @throws CredentialStoreException if retrieval fails
      */
-    public String getSecret(String path, String key) throws VaultException {
-        if (path == null || path.trim().isEmpty()) {
-            throw new VaultException(ROOT_LOGGER.vaultPathCannotBeNullOrEmpty());
-        }
-        if (key == null || key.trim().isEmpty()) {
-            throw new VaultException(ROOT_LOGGER.vaultKeyCannotBeNullOrEmpty());
+    public Map<String, Object> getSecretData(VaultAlias alias) throws CredentialStoreException {
+        if (alias == null) {
+            throw ROOT_LOGGER.vaultAliasCannotBeNull();
         }
 
-        // Get the appropriate Vault instance for this path
-        Vault vault = getVaultForPath(path);
-
-        // Fetch from Vault - the library handles path adjustments internally
-        LogicalResponse response = vault.logical().read(path);
-        int responseStatus = response.getRestResponse().getStatus();
-        if (responseStatus == 200) {
-            Map<String, String> data = response.getData();
-            String value = data.get(key);
-            if (value != null) {
-                ROOT_LOGGER.vaultRetrievedSecret(path, this.vaultUrl);
-            } else {
-                ROOT_LOGGER.vaultKeyNotFoundInSecret(key, path);
-            }
-            return value;
-        }
-        if (responseStatus == 403) {
-            ROOT_LOGGER.vaultForbiddenToRetrieveSecret(path);
-            throw new VaultException(ROOT_LOGGER.vaultForbiddenToRetrieveSecretAtPath(path));
-        }
-        if (responseStatus == 404) {
-            ROOT_LOGGER.vaultSecretNotFoundAtPath(path);
-            return null;
-        }
-
-        throw new VaultException(ROOT_LOGGER.vaultFailedToRetrieveSecretHttp(path, key, responseStatus));
-    }
-
-    /**
-     * Store a secret in Vault
-     */
-    public void putSecret(String path, String key, String value) throws VaultException {
-        if (path == null || path.trim().isEmpty()) {
-            throw new VaultException(ROOT_LOGGER.vaultPathCannotBeNullOrEmpty());
-        }
-        if (key == null || key.trim().isEmpty()) {
-            throw new VaultException(ROOT_LOGGER.vaultKeyCannotBeNullOrEmpty());
-        }
-        if (value == null) {
-            throw new VaultException(ROOT_LOGGER.vaultValueCannotBeNull());
-        }
-
-        // Get the appropriate Vault instance for this path
-        Vault vault = getVaultForPath(path);
-
-        Map<String, Object> nameValuePairs = new HashMap<>();
-        // Read existing path to preserve other keys if those exist
-        LogicalResponse readResponse = vault.logical().read(path);
-        int readStatus = readResponse.getRestResponse().getStatus();
-        if (readStatus == 200) {
-            Map<String, String> existingData = readResponse.getData();
-            if (existingData != null) {
-                nameValuePairs.putAll(existingData);
-            }
-        }
-
-        nameValuePairs.put(key, value);
-        LogicalResponse response = vault.logical().write(path, nameValuePairs);
-        int responseStatus = response.getRestResponse().getStatus();
-        if (responseStatus == 200 || responseStatus == 204) {
-            ROOT_LOGGER.vaultStoredSecret(path, this.vaultUrl);
-            return;
-        }
-        if (responseStatus == 403) {
-            throw new VaultException(ROOT_LOGGER.vaultForbiddenToStoreSecretAtPath(path));
-        }
-
-        throw new VaultException(ROOT_LOGGER.vaultFailedToStoreSecretHttp(path, key, responseStatus));
-    }
-
-    /**
-     * Remove a secret from Vault
-     */
-    public void removeSecret(String path, String key) throws VaultException {
-        if (path == null || path.trim().isEmpty()) {
-            throw new VaultException(ROOT_LOGGER.vaultPathCannotBeNullOrEmpty());
-        }
-        if (key == null || key.trim().isEmpty()) {
-            throw new VaultException(ROOT_LOGGER.vaultKeyCannotBeNullOrEmpty());
-        }
-
-        // Get the appropriate Vault instance for this path
-        Vault vault = getVaultForPath(path);
-
-        // Read existing path to preserve other keys at the same path
-        Map<String, Object> nameValuePairs = new HashMap<>();
-        LogicalResponse readResponse = vault.logical().read(path);
-        int readStatus = readResponse.getRestResponse().getStatus();
-        if (readStatus == 200) {
-            Map<String, String> existingData = readResponse.getData();
-            if (existingData != null) {
-                nameValuePairs.putAll(existingData);
-            }
-        }
-
-        if (!nameValuePairs.containsKey(key)) {
-            ROOT_LOGGER.vaultKeyDoesNotExistAtPath(key, path);
-            return;
-        }
-        nameValuePairs.remove(key);
-        if (nameValuePairs.isEmpty()) {
-            LogicalResponse deleteResponse = vault.logical().delete(path);
-            int deleteStatus = deleteResponse.getRestResponse().getStatus();
-            if (deleteStatus == 200 || deleteStatus == 204) {
-                ROOT_LOGGER.vaultDeletedSecretPath(path);
-                return;
-            }
-            if (deleteStatus == 403) {
-                throw new VaultException(ROOT_LOGGER.vaultForbiddenToDeleteSecretAtPath(path));
-            }
-            throw new VaultException(ROOT_LOGGER.vaultFailedToDeleteSecretHttp(path, deleteStatus));
-        } else {
-            // Write back the remaining keys
-            LogicalResponse writeResponse = vault.logical().write(path, nameValuePairs);
-            int writeStatus = writeResponse.getRestResponse().getStatus();
-            if (writeStatus == 200 || writeStatus == 204) {
-                ROOT_LOGGER.vaultRemovedKeyFromPath(key, path);
-                return;
-            }
-            if (writeStatus == 403) {
-                throw new VaultException(ROOT_LOGGER.vaultForbiddenToUpdateSecretAtPath(path));
-            }
-            throw new VaultException(ROOT_LOGGER.vaultFailedToUpdateSecretAfterRemoveKey(path, key, writeStatus));
-        }
-    }
-
-    /**
-     * Get all keys for a specific path
-     */
-    public Set<String> getKeysForPath(String path) throws VaultException {
-        Vault vault = getVaultForPath(path);
-        LogicalResponse response = vault.logical().read(path);
-        int responseStatus = response.getRestResponse().getStatus();
-        if (responseStatus == 200) {
-            Map<String, String> data = response.getData();
-            if (data != null && !data.isEmpty()) {
-                return new HashSet<>(data.keySet());
-            }
-            return new HashSet<>();
-        } else if (responseStatus == 404) {
-            throw new VaultException(ROOT_LOGGER.vaultPathDoesNotExistOrForbidden(path));
-        } else {
-            throw new VaultException(ROOT_LOGGER.vaultFailedToReadAliasesOnPath(path));
-        }
-    }
-
-    /**
-     * Get a set of all items at a given path (without the parent path prefix)
-     */
-    public Set<String> listAllItemsAtPath(String path) throws VaultException {
-        if (path == null || path.trim().isEmpty()) {
-            throw new VaultException(ROOT_LOGGER.vaultPathCannotBeNullOrEmpty());
-        }
-
-        // Get the appropriate Vault instance for this path
-        Vault vault = getVaultForPath(path);
-
-        // vault expects trailing slash with list operation
-        String listPath = path.endsWith("/") ? path : path + "/";
+        String path = constructVaultPath(alias);
 
         try {
-            LogicalResponse response = vault.logical().list(listPath);
+            // Get the appropriate Vault instance based on alias engine type
+            Vault vault = getVaultForAlias(alias);
+
+            // Fetch from Vault - the library handles path adjustments internally
+            LogicalResponse response = vault.logical().read(path);
             int responseStatus = response.getRestResponse().getStatus();
             if (responseStatus == 200) {
-                List<String> keys = response.getListData();
-                if (keys != null && !keys.isEmpty()) {
-                    return new HashSet<>(keys);
+                Map<String, String> data = response.getData();
+                if (data != null) {
+                    ROOT_LOGGER.vaultRetrievedSecret(path, this.vaultUrl);
+                    // Convert Map<String, String> to Map<String, Object> for KeyPathResolver
+                    Map<String, Object> result = new HashMap<>();
+                    result.putAll(data);
+                    return result;
                 }
-                return new HashSet<>();
-            } else if (responseStatus == 404) {
-                throw new VaultException(ROOT_LOGGER.vaultPathNotFoundInVault(path));
-            } else if (responseStatus == 403) {
-                throw new VaultException(ROOT_LOGGER.vaultForbiddenToListSubpathsAtPath(path));
-            } else {
-                throw new VaultException(ROOT_LOGGER.vaultFailedToListSubpathsHttp(path, responseStatus));
+                return null;
             }
-        } catch (ClassCastException e) {
-            throw new VaultException(ROOT_LOGGER.vaultUnexpectedListSubpathsFormat(path, e.getMessage()));
+            if (responseStatus == 403) {
+                ROOT_LOGGER.vaultForbiddenToRetrieveSecret(path);
+                throw ROOT_LOGGER.vaultForbiddenToRetrieveSecretAtPath(path);
+            }
+            if (responseStatus == 404) {
+                ROOT_LOGGER.vaultSecretNotFoundAtPath(path);
+                return null;
+            }
+
+            throw ROOT_LOGGER.vaultFailedToRetrieveSecretHttp(path, alias.getKeyPath(), responseStatus);
+        } catch (VaultException e) {
+            throw new CredentialStoreException("Failed to retrieve secret from Vault: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Store a secret value in Vault using the new alias format.
+     * This method reads the existing secret data, updates the specified key path,
+     * and writes the entire secret back to Vault.
+     *
+     * @param alias the parsed vault alias specifying location and key path
+     * @param value the value to store
+     * @throws CredentialStoreException if the operation fails
+     */
+    Map<String, Object> putSecretData(VaultAlias alias, String value) throws CredentialStoreException {
+        if (alias == null) {
+            throw ROOT_LOGGER.vaultAliasCannotBeNull();
+        }
+        if (value == null) {
+            throw ROOT_LOGGER.vaultValueCannotBeNull();
+        }
+
+        String path = constructVaultPath(alias);
+
+        try {
+            Vault vault = getVaultForAlias(alias);
+
+            // Read existing secret data to preserve other keys
+            Map<String, Object> secretData = new HashMap<>();
+            LogicalResponse readResponse = vault.logical().read(path);
+            int readStatus = readResponse.getRestResponse().getStatus();
+            if (readStatus == 200) {
+                Map<String, String> existingData = readResponse.getData();
+                if (existingData != null) {
+                    secretData.putAll(existingData);
+                }
+            }
+
+            // Update the value at the specified key path
+            String keyPath = alias.getKeyPath();
+            if (keyPath.contains("/")) {
+                // Nested key path - need to traverse and update
+                KeyPathResolver.setNestedValue(secretData, keyPath, value);
+            } else {
+                // Simple key - direct update
+                secretData.put(keyPath, value);
+            }
+
+            // Write back to Vault
+            LogicalResponse response = vault.logical().write(path, secretData);
+            int responseStatus = response.getRestResponse().getStatus();
+            if (responseStatus == 200 || responseStatus == 204) {
+                ROOT_LOGGER.vaultStoredSecret(path, this.vaultUrl);
+                return secretData;
+            }
+            if (responseStatus == 403) {
+                throw ROOT_LOGGER.vaultForbiddenToStoreSecretAtPath(path);
+            }
+
+            throw ROOT_LOGGER.vaultFailedToStoreSecretHttp(path, keyPath, responseStatus);
+        } catch (VaultException e) {
+            throw new CredentialStoreException("Failed to store secret in Vault: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Remove a secret value from Vault using the new alias format.
+     * This method reads the existing secret data, removes the specified key path,
+     * and either writes the remaining data back or deletes the entire secret if empty.
+     *
+     * @param alias the parsed vault alias specifying location and key path
+     * @throws CredentialStoreException if the operation fails
+     */
+    void removeSecretData(VaultAlias alias) throws CredentialStoreException {
+        if (alias == null) {
+            throw ROOT_LOGGER.vaultAliasCannotBeNull();
+        }
+
+        String path = constructVaultPath(alias);
+
+        try {
+            Vault vault = getVaultForAlias(alias);
+
+            // Read existing secret data
+            Map<String, Object> secretData = new HashMap<>();
+            LogicalResponse readResponse = vault.logical().read(path);
+            int readStatus = readResponse.getRestResponse().getStatus();
+            if (readStatus == 200) {
+                Map<String, String> existingData = readResponse.getData();
+                if (existingData != null) {
+                    secretData.putAll(existingData);
+                }
+            }
+
+            // Remove the value at the specified key path
+            String keyPath = alias.getKeyPath();
+            boolean removed;
+            if (keyPath.contains("/")) {
+                // Nested key path - need to traverse and remove
+                removed = KeyPathResolver.removeNestedValue(secretData, keyPath);
+            } else {
+                // Simple key - direct removal
+                removed = secretData.remove(keyPath) != null;
+            }
+
+            if (!removed) {
+                ROOT_LOGGER.vaultKeyDoesNotExistAtPath(keyPath, path);
+                return;
+            }
+
+            // If secret data is now empty, delete the entire secret
+            if (secretData.isEmpty()) {
+                LogicalResponse deleteResponse = vault.logical().delete(path);
+                int deleteStatus = deleteResponse.getRestResponse().getStatus();
+                if (deleteStatus == 200 || deleteStatus == 204) {
+                    ROOT_LOGGER.vaultDeletedSecretPath(path);
+                    return;
+                }
+                if (deleteStatus == 403) {
+                    throw ROOT_LOGGER.vaultForbiddenToDeleteSecretAtPath(path);
+                }
+                throw ROOT_LOGGER.vaultFailedToDeleteSecretHttp(path, deleteStatus);
+            } else {
+                // Write back the remaining keys
+                LogicalResponse writeResponse = vault.logical().write(path, secretData);
+                int writeStatus = writeResponse.getRestResponse().getStatus();
+                if (writeStatus == 200 || writeStatus == 204) {
+                    ROOT_LOGGER.vaultRemovedKeyFromPath(keyPath, path);
+                    return;
+                }
+                if (writeStatus == 403) {
+                    throw ROOT_LOGGER.vaultForbiddenToUpdateSecretAtPath(path);
+                }
+                throw ROOT_LOGGER.vaultFailedToUpdateSecretAfterRemoveKey(path, keyPath, writeStatus);
+            }
+        } catch (VaultException e) {
+            throw new CredentialStoreException("Failed to remove secret from Vault: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import javax.net.ssl.SSLContext;
 
@@ -32,8 +31,6 @@ import io.github.jopenlibs.vault.response.LogicalResponse;
  * Vault Connector
  */
 public class VaultConnector {
-
-    private static final Predicate<String> DEFAULT_KV_V1_FALLBACK_PREDICATE = path -> false;
 
     private final String vaultUrl;
     private final String token;
@@ -59,14 +56,10 @@ public class VaultConnector {
     private final Map<String, Vault> vaultInstanceCache = new HashMap<>();
 
     public VaultConnector(String vaultUrl, String token, String namespace, SslConfig sslConfig, boolean sslVerify) {
-        this(vaultUrl, token, namespace, sslConfig, sslVerify, null, DEFAULT_KV_V1_FALLBACK_PREDICATE);
+        this(vaultUrl, token, namespace, sslConfig, sslVerify, null);
     }
 
     public VaultConnector(String vaultUrl, String token, String namespace, SslConfig sslConfig, boolean sslVerify, SSLContext sslContext) {
-        this(vaultUrl, token, namespace, sslConfig, sslVerify, sslContext, DEFAULT_KV_V1_FALLBACK_PREDICATE);
-    }
-
-    public VaultConnector(String vaultUrl, String token, String namespace, SslConfig sslConfig, boolean sslVerify, SSLContext sslContext, Predicate<String> kvV1FallbackPredicate) {
         this.vaultUrl = vaultUrl;
         this.token = token;
         this.namespace = namespace;
@@ -80,14 +73,10 @@ public class VaultConnector {
     }
 
     public VaultConnector(String vaultUrl, JwtConfig jwtConfig, String namespace, SslConfig sslConfig) {
-        this(vaultUrl, jwtConfig, namespace, sslConfig, null, DEFAULT_KV_V1_FALLBACK_PREDICATE);
+        this(vaultUrl, jwtConfig, namespace, sslConfig, null);
     }
 
     public VaultConnector(String vaultUrl, JwtConfig jwtConfig, String namespace, SslConfig sslConfig, SSLContext sslContext) {
-        this(vaultUrl, jwtConfig, namespace, sslConfig, sslContext, DEFAULT_KV_V1_FALLBACK_PREDICATE);
-    }
-
-    public VaultConnector(String vaultUrl, JwtConfig jwtConfig, String namespace, SslConfig sslConfig, SSLContext sslContext, Predicate<String> kvV1FallbackPredicate) {
         this.vaultUrl = vaultUrl;
         this.token = null;
         this.namespace = namespace;

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
@@ -165,18 +165,18 @@ public class VaultConnector {
     }
 
     /**
-     * Get the appropriate Vault instance based on the alias engine type and mount path.
+     * Get the appropriate Vault instance based on the path's engine type and mount path.
      * Creates Vault instances lazily on first use and caches them.
      *
      * For KV v2, different mount path segment counts require different Vault instances
      * because the driver needs to know where to insert the /data/ segment.
      *
-     * @param alias the parsed vault alias containing engine type and path information
+     * @param path the vault path containing engine type and mount path information
      * @return the appropriate Vault instance for the specified engine type and mount path
      */
-    private Vault getVaultForAlias(VaultAlias alias) throws CredentialStoreException {
-        String engineType = alias.getEngineType();
-        String mountPath = alias.getMountPath();
+    private Vault getVaultForPath(VaultPath path) throws CredentialStoreException {
+        String engineType = path.getEngineType();
+        String mountPath = path.getMountPath();
 
         // Determine KV version and segment count
         final int kvVersion;
@@ -274,12 +274,12 @@ public class VaultConnector {
      * Construct the full Vault path from alias components.
      * Combines mount path and secret path with proper formatting.
      *
-     * @param alias the parsed vault alias
+     * @param path the vault path
      * @return the full path for Vault API calls
      */
-    private String constructVaultPath(VaultAlias alias) {
-        String mountPath = alias.getMountPath();
-        String secretPath = alias.getSecretPath();
+    private String constructVaultPath(VaultPath path) {
+        String mountPath = path.getMountPath();
+        String secretPath = path.getSecretPath();
 
         // Ensure mount path doesn't end with /
         if (mountPath.endsWith("/")) {
@@ -385,27 +385,27 @@ public class VaultConnector {
     /**
      * Get all keys (field names) for a secret at the given path.
      *
-     * @param alias the vault alias specifying the secret location
+     * @param path the vault path specifying the secret location
      * @return set of key names in the secret
      * @throws CredentialStoreException if reading fails
      */
-    public List<String> getKeysForSecret(VaultAlias alias) throws CredentialStoreException {
-        Map<String, Object> secretData = getSecretData(alias);
+    public List<String> getKeysForSecret(VaultPath path) throws CredentialStoreException {
+        Map<String, Object> secretData = getSecretData(path);
         if (secretData == null) {
             return new ArrayList<>();
         }
         return new ArrayList<>(secretData.keySet());
     }
 
-    public Map<String, Object> getSecretData(VaultAlias alias) throws CredentialStoreException {
-        if (alias == null) {
+    public Map<String, Object> getSecretData(VaultPath vaultPath) throws CredentialStoreException {
+        if (vaultPath == null) {
             throw ROOT_LOGGER.vaultAliasCannotBeNull();
         }
 
-        String path = constructVaultPath(alias);
+        String path = constructVaultPath(vaultPath);
 
         try {
-            Vault vault = getVaultForAlias(alias);
+            Vault vault = getVaultForPath(vaultPath);
             LogicalResponse response = vault.logical().read(path);
             int responseStatus = response.getRestResponse().getStatus();
             if (responseStatus == 200) {
@@ -428,7 +428,7 @@ public class VaultConnector {
                 return null;
             }
 
-            throw ROOT_LOGGER.vaultFailedToRetrieveSecretHttp(path, alias.getKeyPath(), responseStatus);
+            throw ROOT_LOGGER.vaultFailedToRetrieveSecretHttp(path, vaultPath.getSecretPath(), responseStatus);
         } catch (VaultException e) {
             throw new CredentialStoreException("Failed to retrieve secret from Vault: " + e.getMessage(), e);
         }
@@ -454,7 +454,7 @@ public class VaultConnector {
         String path = constructVaultPath(alias);
 
         try {
-            Vault vault = getVaultForAlias(alias);
+            Vault vault = getVaultForPath(alias);
 
             // Read existing secret data to preserve other keys
             Map<String, Object> secretData = new HashMap<>();
@@ -510,7 +510,7 @@ public class VaultConnector {
         String path = constructVaultPath(alias);
 
         try {
-            Vault vault = getVaultForAlias(alias);
+            Vault vault = getVaultForPath(alias);
 
             // Read existing secret data
             Map<String, Object> secretData = new HashMap<>();

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
@@ -174,24 +174,43 @@ public class VaultConnector {
      * @param alias the parsed vault alias containing engine type and path information
      * @return the appropriate Vault instance for the specified engine type and mount path
      */
-    private synchronized Vault getVaultForAlias(VaultAlias alias) throws CredentialStoreException {
+    private Vault getVaultForAlias(VaultAlias alias) throws CredentialStoreException {
         String engineType = alias.getEngineType();
         String mountPath = alias.getMountPath();
 
         // Determine KV version and segment count
         final int kvVersion;
         final int segmentCount;
-        final String cacheKey;
 
         if ("KVv1".equals(engineType)) {
             // KV v1 doesn't use /data/ insertion, so segment count doesn't matter
             kvVersion = 1;
             segmentCount = 0; // irrelevant for v1
-            cacheKey = "KVv1";
         } else {
             // KV v2 - need to account for mount path segment count
             kvVersion = 2;
             segmentCount = countMountPathSegments(mountPath);
+        }
+
+        return getOrCreateVaultInstance(kvVersion, segmentCount);
+    }
+
+    /**
+     * Get or create a cached Vault instance for the specified KV version and segment count.
+     * This method ensures that Vault instances are reused efficiently across operations.
+     *
+     * @param kvVersion the KV engine version (1 or 2)
+     * @param segmentCount the number of path segments in the mount path
+     * @return the cached or newly created Vault instance
+     * @throws CredentialStoreException if Vault instance creation fails
+     */
+    private synchronized Vault getOrCreateVaultInstance(int kvVersion, int segmentCount) throws CredentialStoreException {
+        final String cacheKey;
+        if (kvVersion == 1) {
+            // KV v1 doesn't use /data/ insertion, so segment count doesn't matter
+            cacheKey = "KVv1";
+        } else {
+            // KV v2 - need to account for mount path segment count
             cacheKey = "KVv2-" + segmentCount;
         }
 
@@ -338,11 +357,11 @@ public class VaultConnector {
                 listPath = mountPath + "/" + secretPath;
             }
 
-            // Create a Vault instance for listing
+            // Get or create a cached Vault instance for listing
             // Use the mount path segment count for proper /metadata/ insertion
             int kvVersion = VaultAlias.engineTypeToVersion(engineType);
             int segmentCount = countMountPathSegments(mountPath);
-            Vault vault = createVaultInstance(kvVersion, segmentCount);
+            Vault vault = getOrCreateVaultInstance(kvVersion, segmentCount);
             LogicalResponse response = vault.logical().list(listPath);
             int status = response.getRestResponse().getStatus();
 

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultCredentialSource.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultCredentialSource.java
@@ -28,7 +28,7 @@ import org.wildfly.security.password.spec.ClearPasswordSpec;
  * This class has been updated to use the new alias format internally while maintaining
  * backwards compatibility with the legacy path/key constructor.
  */
-class VaultCredentialSource implements CredentialSource {
+public class VaultCredentialSource implements CredentialSource {
 
     private final VaultConnector vaultConnector;
     private final VaultAlias alias;
@@ -38,7 +38,80 @@ class VaultCredentialSource implements CredentialSource {
     };
 
     /**
+     * Construct a new instance using an alias string.
+     * <p>
+     * The alias string should be in the new format:
+     * {@code [engine=TYPE][@mount-path]#secret-path?key-path}
+     * <p>
+     * Examples:
+     * <ul>
+     *   <li>{@code #myapp/database?password} - Simple key with defaults</li>
+     *   <li>{@code engine=KVv1@secret-v1#myapp?password} - Explicit engine and mount</li>
+     *   <li>{@code @custom-mount#myapp/config?db.host} - Custom mount with nested key</li>
+     * </ul>
+     *
+     * @param vaultConnector the service connecting to vault instance (must not be {@code null})
+     * @param alias the vault alias string specifying the secret location and key (must not be {@code null})
+     * @throws IllegalArgumentException if the alias format is invalid
+     */
+    public VaultCredentialSource(VaultConnector vaultConnector, String alias) {
+        if (vaultConnector == null) {
+            throw ROOT_LOGGER.vaultConnectorCannotBeNull();
+        }
+        if (alias == null || alias.trim().isEmpty()) {
+            throw new IllegalArgumentException("Alias cannot be null or empty");
+        }
+
+        this.vaultConnector = vaultConnector;
+        try {
+            this.alias = VaultAlias.parse(alias, "KVv2", "secret");
+        } catch (CredentialStoreException e) {
+            throw new IllegalArgumentException("Failed to parse alias: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Construct a new instance using explicit component parameters.
+     * <p>
+     * This constructor allows you to specify all components of the vault secret location explicitly:
+     * <ul>
+     *   <li>engineType - The KV engine type (KVv1 or KVv2)</li>
+     *   <li>mountPath - The mount path where the KV engine is mounted (e.g., "secret", "team/backend")</li>
+     *   <li>secretPath - The path to the secret within the mount (e.g., "myapp/database")</li>
+     *   <li>keyPath - The key within the secret to retrieve (e.g., "password", "database/credentials/password")</li>
+     * </ul>
+     *
+     * @param vaultConnector the service connecting to vault instance (must not be {@code null})
+     * @param engineType the engine type (KVv1 or KVv2, must not be {@code null})
+     * @param mountPath the mount path (must not be {@code null})
+     * @param secretPath the secret path (must not be {@code null})
+     * @param keyPath the key path (must not be {@code null})
+     * @throws IllegalArgumentException if any parameter is invalid
+     */
+    public VaultCredentialSource(VaultConnector vaultConnector, String engineType, String mountPath,
+                                  String secretPath, String keyPath) {
+        if (vaultConnector == null) {
+            throw ROOT_LOGGER.vaultConnectorCannotBeNull();
+        }
+
+        this.vaultConnector = vaultConnector;
+        try {
+            this.alias = VaultAlias.create(engineType, mountPath, secretPath, keyPath);
+        } catch (CredentialStoreException e) {
+            throw new IllegalArgumentException("Failed to create alias from components: " + e.getMessage(), e);
+        }
+    }
+
+    /**
      * Construct a new instance using legacy path/key format.
+     * <p>
+     * <b>Deprecated:</b> This constructor is deprecated because the {@code secretPath} parameter
+     * is ambiguous - it's unclear whether it includes the mount path or not. Use one of the
+     * following constructors instead:
+     * <ul>
+     *   <li>{@link #VaultCredentialSource(VaultConnector, String)} - with a full alias string</li>
+     *   <li>{@link #VaultCredentialSource(VaultConnector, String, String, String, String)} - with explicit components</li>
+     * </ul>
      * <p>
      * This constructor maintains backwards compatibility by converting the legacy path/key
      * format to the new alias format internally. The conversion assumes:
@@ -51,7 +124,10 @@ class VaultCredentialSource implements CredentialSource {
      * @param vaultConnector the service connecting to vault instance (must not be {@code null})
      * @param secretPath the path to the secret to retrieve from (must not be {@code null})
      * @param secretKey the key of the secret (must not be {@code null})
+     * @deprecated Use {@link #VaultCredentialSource(VaultConnector, String)} or
+     *             {@link #VaultCredentialSource(VaultConnector, String, String, String, String)} instead
      */
+    @Deprecated
     public VaultCredentialSource(VaultConnector vaultConnector, String secretPath, String secretKey) {
         if (vaultConnector == null) {
             throw ROOT_LOGGER.vaultConnectorCannotBeNull();
@@ -66,10 +142,19 @@ class VaultCredentialSource implements CredentialSource {
         this.vaultConnector = vaultConnector;
 
         // Convert legacy path/key to new alias format
-        // Assume default mount "secret" and KVv2 engine for legacy usage
-        String aliasString = secretPath + "?" + secretKey;
+        // The secretPath in legacy format includes the mount path (e.g., "secret/testing1")
         try {
-            this.alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+            // Extract mount path and secret path from legacy format
+            String mountPath = "secret"; // default
+            String actualSecretPath = secretPath;
+
+            if (secretPath.contains("/")) {
+                int firstSlash = secretPath.indexOf('/');
+                mountPath = secretPath.substring(0, firstSlash);
+                actualSecretPath = secretPath.substring(firstSlash + 1);
+            }
+
+            this.alias = VaultAlias.create("KVv2", mountPath, actualSecretPath, secretKey);
         } catch (CredentialStoreException e) {
             throw new IllegalArgumentException("Failed to convert legacy path/key to alias format: " + e.getMessage(), e);
         }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultCredentialSource.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultCredentialSource.java
@@ -9,36 +9,48 @@ import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger
 import java.io.IOException;
 import java.security.Provider;
 import java.security.spec.AlgorithmParameterSpec;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import org.wildfly.security.auth.SupportLevel;
 import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.source.CredentialSource;
+import org.wildfly.security.credential.store.CredentialStoreException;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.WildFlyElytronPasswordProvider;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 
 /**
- *  A credential source which is backed by a HashiCorp Vault.
+ * A credential source which is backed by a HashiCorp Vault.
+ * <p>
+ * This class has been updated to use the new alias format internally while maintaining
+ * backwards compatibility with the legacy path/key constructor.
  */
 class VaultCredentialSource implements CredentialSource {
 
     private final VaultConnector vaultConnector;
-    private final String secretPath;
-    private final String secretKey;
+    private final VaultAlias alias;
 
     public static Supplier<Provider[]> ELYTRON_PASSWORD_PROVIDERS = () -> new Provider[]{
             WildFlyElytronPasswordProvider.getInstance()
     };
 
     /**
-     * Construct a new instance.
+     * Construct a new instance using legacy path/key format.
+     * <p>
+     * This constructor maintains backwards compatibility by converting the legacy path/key
+     * format to the new alias format internally. The conversion assumes:
+     * <ul>
+     *   <li>Default engine type: KVv2</li>
+     *   <li>Default mount path: secret</li>
+     *   <li>Alias format: {@code secretPath?secretKey}</li>
+     * </ul>
      *
      * @param vaultConnector the service connecting to vault instance (must not be {@code null})
      * @param secretPath the path to the secret to retrieve from (must not be {@code null})
-     * @param secretKey the key of the secret
+     * @param secretKey the key of the secret (must not be {@code null})
      */
     public VaultCredentialSource(VaultConnector vaultConnector, String secretPath, String secretKey) {
         if (vaultConnector == null) {
@@ -52,8 +64,15 @@ class VaultCredentialSource implements CredentialSource {
         }
 
         this.vaultConnector = vaultConnector;
-        this.secretPath = secretPath;
-        this.secretKey = secretKey;
+
+        // Convert legacy path/key to new alias format
+        // Assume default mount "secret" and KVv2 engine for legacy usage
+        String aliasString = secretPath + "?" + secretKey;
+        try {
+            this.alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        } catch (CredentialStoreException e) {
+            throw new IllegalArgumentException("Failed to convert legacy path/key to alias format: " + e.getMessage(), e);
+        }
     }
 
     //TODO support more credential types
@@ -70,7 +89,14 @@ class VaultCredentialSource implements CredentialSource {
         if (credentialType == PasswordCredential.class) {
             try {
                 vaultConnector.configure();
-                String password = vaultConnector.getSecret(secretPath, secretKey);
+
+                // Use new alias-based methods
+                Map<String, Object> secretData = vaultConnector.getSecretData(alias);
+                if (secretData == null) {
+                    return null;
+                }
+
+                String password = KeyPathResolver.resolveKeyPath(secretData, alias.getKeyPath());
                 if (password != null) {
                     PasswordFactory factory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR, ELYTRON_PASSWORD_PROVIDERS);
                     ClearPassword clearPassword = (ClearPassword) factory.generatePassword(

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultCredentialSource.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultCredentialSource.java
@@ -23,7 +23,7 @@ import org.wildfly.security.password.spec.ClearPasswordSpec;
 /**
  *  A credential source which is backed by a HashiCorp Vault.
  */
-public class VaultCredentialSource implements CredentialSource {
+class VaultCredentialSource implements CredentialSource {
 
     private final VaultConnector vaultConnector;
     private final String secretPath;
@@ -50,7 +50,7 @@ public class VaultCredentialSource implements CredentialSource {
         if (secretKey == null || secretKey.trim().isEmpty()) {
             throw ROOT_LOGGER.vaultSecretKeyInvalid();
         }
-        
+
         this.vaultConnector = vaultConnector;
         this.secretPath = secretPath;
         this.secretKey = secretKey;

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultPath.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultPath.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger.ROOT_LOGGER;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+import org.wildfly.security.credential.store.CredentialStoreException;
+
+/**
+ * Represents a parsed Vault path consisting of engine type, mount path, and secret path.
+ *
+ * <p>This class serves as the base for {@link VaultAlias} and can be used independently
+ * for operations that don't require a specific key path (e.g., listing secrets).
+ *
+ * <p>Format: {@code [engine=TYPE][@mount-path]#secret-path}
+ *
+ * <p>Components:
+ * <ul>
+ *   <li>{@code engine=TYPE} - Optional engine type specification (e.g., {@code engine=KVv1}, {@code engine=KVv2})</li>
+ *   <li>{@code @mount-path} - Optional mount path (e.g., {@code @secret}, {@code @team/backend})</li>
+ *   <li>{@code #secret-path} - Secret path (e.g., {@code #myapp/database})</li>
+ * </ul>
+ *
+ * <p>Examples:
+ * <ul>
+ *   <li>{@code #myapp/database} - Simple path with defaults</li>
+ *   <li>{@code engine=KVv1@secret-v1#myapp} - Explicit engine and mount</li>
+ *   <li>{@code @custom-mount#my.app.config} - Custom mount with dots in path</li>
+ *   <li>{@code secret/myapp} - Legacy format (when supported)</li>
+ * </ul>
+ */
+class VaultPath {
+
+    private final String engineType;
+    private final String mountPath;
+    private final String secretPath;
+
+    /**
+     * Protected constructor - use factory methods to create instances.
+     *
+     * @param engineType the engine type (KVv1 or KVv2)
+     * @param mountPath the mount path
+     * @param secretPath the secret path
+     */
+    protected VaultPath(String engineType, String mountPath, String secretPath) {
+        this.engineType = engineType;
+        this.mountPath = mountPath;
+        this.secretPath = secretPath;
+    }
+
+    /**
+     * Create a VaultPath directly from components without parsing.
+     *
+     * @param engineType the engine type (KVv1 or KVv2)
+     * @param mountPath the mount path
+     * @param secretPath the secret path (can be empty for root listing)
+     * @return a new VaultPath instance
+     * @throws CredentialStoreException if the engine type is invalid or any required component is null
+     */
+    static VaultPath create(String engineType, String mountPath, String secretPath) throws CredentialStoreException {
+        // Validate required parameters
+        if (engineType == null || engineType.isEmpty()) {
+            throw ROOT_LOGGER.engineTypeCannotBeEmpty("direct creation");
+        }
+        if (mountPath == null || mountPath.isEmpty()) {
+            throw ROOT_LOGGER.mountPathCannotBeEmpty("direct creation");
+        }
+        if (secretPath == null) {
+            throw ROOT_LOGGER.secretPathCannotBeEmpty("direct creation");
+        }
+
+        // Validate engine type
+        if (!engineType.equals("KVv1") && !engineType.equals("KVv2")) {
+            throw ROOT_LOGGER.invalidEngineType(engineType);
+        }
+
+        return new VaultPath(engineType, mountPath, secretPath);
+    }
+
+    /**
+     * Parse a vault path or alias string with specified defaults and legacy format support.
+     *
+     * <p>This method parses paths in the format: {@code [engine=TYPE][@mount-path]#secret-path[?key-path]}
+     * or legacy format {@code mount/secret-path[.key]} (when supported).
+     *
+     * @param <T> the type of VaultPath to return (VaultPath or VaultAlias)
+     * @param input the path or alias string to parse
+     * @param defaultEngineType the default engine type to use if not specified
+     * @param defaultMountPath the default mount path to use if not specified
+     * @param supportLegacyFormat whether to support legacy format
+     * @param requireKey whether a key path is required (true for VaultAlias, false for VaultPath)
+     * @param resultClass the class of the result type
+     * @return the parsed VaultPath or VaultAlias
+     * @throws CredentialStoreException if the format is invalid
+     */
+    @SuppressWarnings("unchecked")
+    static <T extends VaultPath> T parse(String input, String defaultEngineType, String defaultMountPath,
+                                          boolean supportLegacyFormat, boolean requireKey, Class<T> resultClass)
+            throws CredentialStoreException {
+        if (input == null || input.isEmpty()) {
+            throw ROOT_LOGGER.aliasCannotBeNullOrEmpty();
+        }
+
+        ROOT_LOGGER.debugf("Parsing vault %s: %s", requireKey ? "alias" : "path", input);
+
+        // Check if it's new format (contains ?, #, @, or starts with engine=)
+        boolean hasNewFormatIndicators = input.contains("?") || input.contains("#") ||
+                                         input.contains("@") || input.startsWith("engine=");
+
+        // Extract key path if present (for VaultAlias)
+        String path = input;
+        String keyPath = null;
+        boolean legacyAliasFormatUsed = false;
+        int questionPos = input.indexOf('?');
+
+        if (questionPos != -1) {
+            // New format with ? delimiter
+            path = input.substring(0, questionPos);
+            keyPath = input.substring(questionPos + 1);
+        } else if (requireKey) {
+            // No ? found - check for legacy dot-separated format
+            if (!hasNewFormatIndicators) {
+                // No new format indicators - might be legacy format
+                int lastDot = input.lastIndexOf('.');
+                if (lastDot != -1) {
+                    if (supportLegacyFormat) {
+                        // Legacy format: secret.key or mount/secret.key (split on last dot)
+                        path = input.substring(0, lastDot);
+                        keyPath = input.substring(lastDot + 1);
+                        legacyAliasFormatUsed = true;
+
+                        // Convert to new format for logging
+                        String newFormat = path + "?" + keyPath;
+                        ROOT_LOGGER.legacyAliasFormatDeprecated(input, newFormat);
+                    } else {
+                        // Legacy format detected but not supported
+                        String newFormat = input.substring(0, lastDot) + "?" + input.substring(lastDot + 1);
+                        throw ROOT_LOGGER.legacyAliasFormatNotSupported(input, newFormat);
+                    }
+                } else {
+                    // No dot found - not valid legacy format either
+                    throw ROOT_LOGGER.missingQuestionDelimiterBeforeKeyPath(input);
+                }
+            } else {
+                // Has new format indicators but no ? - invalid
+                throw ROOT_LOGGER.missingQuestionDelimiterBeforeKeyPath(input);
+            }
+        }
+
+        // Now parse the path part
+        // If we used legacy alias format (dot-separated), don't allow legacy path format (slash-separated)
+        // to avoid double-parsing (e.g., "mount/secret.key" shouldn't be parsed as mount twice)
+        boolean allowLegacyPathFormat = supportLegacyFormat && !legacyAliasFormatUsed;
+        return parsePathPart(path, keyPath, defaultEngineType, defaultMountPath, allowLegacyPathFormat, requireKey, resultClass);
+    }
+
+    /**
+     * Internal method to parse the path components and optionally create VaultAlias with key.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T extends VaultPath> T parsePathPart(String path, String keyPath, String defaultEngineType,
+                                                          String defaultMountPath, boolean supportLegacyFormat,
+                                                          boolean requireKey, Class<T> resultClass)
+            throws CredentialStoreException {
+        if (path == null || path.isEmpty()) {
+            throw ROOT_LOGGER.aliasCannotBeNullOrEmpty();
+        }
+
+        ROOT_LOGGER.debugf("Parsing vault path: %s", path);
+
+        // Use local variables to collect parsed values
+        String engineType = defaultEngineType;
+        String mountPath = defaultMountPath;
+        String secretPath;
+
+        // Use index-based parsing to reduce GC pressure
+        int pos = 0;
+        final int length = path.length();
+
+        // 1. Extract engine type (optional, starts with "engine=")
+        if (path.startsWith("engine=")) {
+            pos = 7; // Skip "engine="
+            int nextDelim = findNextDelimiter(path, pos, '@', '#');
+            if (nextDelim == -1) {
+                throw ROOT_LOGGER.invalidEngineSpecificationMissingDelimiter(path);
+            }
+            engineType = path.substring(pos, nextDelim);
+            if (engineType.isEmpty()) {
+                throw ROOT_LOGGER.engineTypeCannotBeEmpty(path);
+            }
+            pos = nextDelim;
+        }
+
+        // 2. Extract mount path (optional, starts with @)
+        if (pos < length && path.charAt(pos) == '@') {
+            pos++; // Skip @
+            int hashPos = path.indexOf('#', pos);
+            if (hashPos == -1) {
+                throw ROOT_LOGGER.missingHashDelimiterAfterMountPath(path);
+            }
+            mountPath = path.substring(pos, hashPos);
+            if (mountPath.isEmpty()) {
+                throw ROOT_LOGGER.mountPathCannotBeEmpty(path);
+            }
+            pos = hashPos;
+        }
+
+        // 3. Extract secret path
+        // The # is required only after @ mount path, otherwise it's optional
+        if (pos < length && path.charAt(pos) == '#') {
+            pos++; // Skip # if present
+        }
+
+        // Extract remaining path
+        String remainingPath = path.substring(pos);
+
+        // Special case: "/" and "" are root paths (equivalent to "#" or "#/")
+        if (remainingPath.equals("/") || remainingPath.isEmpty()) {
+            secretPath = "";  // Root of default mount
+        } else {
+            // Check if this might be legacy format (contains / but no new format indicators)
+            boolean hasNewFormatIndicators = path.contains("@") || path.contains("#") || path.startsWith("engine=");
+
+            if (!hasNewFormatIndicators && remainingPath.contains("/") && supportLegacyFormat) {
+                // Legacy format enabled - parse as mount/secretpath
+                int firstSlash = remainingPath.indexOf('/');
+                mountPath = remainingPath.substring(0, firstSlash);
+                secretPath = remainingPath.substring(firstSlash + 1);
+                ROOT_LOGGER.debugf("Parsed as legacy format: mount=%s, secret=%s", mountPath, secretPath);
+            } else {
+                // New format - use remaining as secret path (slashes are allowed)
+                secretPath = remainingPath;
+            }
+
+            // 4. Handle empty secret path or trailing slash (root listing)
+            if (secretPath.isEmpty() || secretPath.equals("/")) {
+                secretPath = "";  // Normalize to empty for root
+            }
+        }
+
+        // Validate secret path is not empty when parsing aliases (requireKey=true)
+        if (requireKey && secretPath.isEmpty()) {
+            throw ROOT_LOGGER.secretPathCannotBeEmpty(path);
+        }
+
+        // 5. URL-decode each segment separately
+        // CRITICAL: Decode AFTER splitting to avoid double-encoding issues
+        engineType = urlDecode(engineType);
+        mountPath = urlDecode(mountPath);
+        secretPath = urlDecode(secretPath);
+
+        // 6. Validate engine type after URL decoding
+        if (!engineType.equals("KVv1") && !engineType.equals("KVv2")) {
+            throw ROOT_LOGGER.invalidEngineType(engineType);
+        }
+
+        // Validate and decode key path if present
+        if (keyPath != null) {
+            if (keyPath.isEmpty()) {
+                throw ROOT_LOGGER.keyPathCannotBeEmpty(path + "?" + keyPath);
+            }
+            keyPath = urlDecode(keyPath);
+
+            // Validate key path doesn't contain empty segments
+            if (keyPath.contains("/")) {
+                if (keyPath.startsWith("/") || keyPath.endsWith("/") || keyPath.contains("//")) {
+                    throw ROOT_LOGGER.keyPathContainsEmptySegment(keyPath);
+                }
+            }
+        } else if (requireKey) {
+            throw ROOT_LOGGER.keyPathCannotBeEmpty(path);
+        }
+
+        ROOT_LOGGER.debugf("Parsed vault %s: engine=%s, mount=%s, secret=%s%s",
+                          requireKey ? "alias" : "path", engineType, mountPath, secretPath,
+                          keyPath != null ? ", key=" + keyPath : "");
+
+        // Create appropriate instance based on whether key is present
+        if (keyPath != null) {
+            // Return VaultAlias
+            return (T) new VaultAlias(engineType, mountPath, secretPath, keyPath);
+        } else {
+            // Return VaultPath
+            return (T) new VaultPath(engineType, mountPath, secretPath);
+        }
+    }
+
+    /**
+     * Parse a vault path string with specified defaults and legacy format support.
+     *
+     * <p>This method parses paths in the format: {@code [engine=TYPE][@mount-path]#secret-path}
+     * or legacy format {@code mount/secret-path} (when supported).
+     *
+     * @param path the path string to parse
+     * @param defaultEngineType the default engine type to use if not specified
+     * @param defaultMountPath the default mount path to use if not specified
+     * @param supportLegacyFormat whether to support legacy {@code mount/secret} format
+     * @return the parsed VaultPath
+     * @throws CredentialStoreException if the path format is invalid
+     */
+    static VaultPath parse(String path, String defaultEngineType, String defaultMountPath, boolean supportLegacyFormat)
+            throws CredentialStoreException {
+        return parse(path, defaultEngineType, defaultMountPath, supportLegacyFormat, false, VaultPath.class);
+    }
+
+    /**
+     * Find the position of the next delimiter character in the string.
+     *
+     * @param s the string to search
+     * @param start the starting position
+     * @param delims the delimiter characters to search for
+     * @return the position of the first delimiter found, or -1 if none found
+     */
+    protected static int findNextDelimiter(String s, int start, char... delims) {
+        int minPos = -1;
+        for (char delim : delims) {
+            int pos = s.indexOf(delim, start);
+            if (pos != -1 && (minPos == -1 || pos < minPos)) {
+                minPos = pos;
+            }
+        }
+        return minPos;
+    }
+
+    /**
+     * URL-decode a string using UTF-8 encoding.
+     *
+     * @param s the string to decode
+     * @return the decoded string, or the original string if decoding fails
+     */
+    protected static String urlDecode(String s) {
+        if (s == null) {
+            return null;
+        }
+        try {
+            return URLDecoder.decode(s, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // UTF-8 should always be supported, but if not, return as-is
+            return s;
+        } catch (IllegalArgumentException e) {
+            // Invalid URL encoding - return as-is
+            return s;
+        }
+    }
+
+    /**
+     * Get the engine type (KVv1 or KVv2).
+     *
+     * @return the engine type
+     */
+    public String getEngineType() {
+        return engineType;
+    }
+
+    /**
+     * Get the mount path.
+     *
+     * @return the mount path
+     */
+    public String getMountPath() {
+        return mountPath;
+    }
+
+    /**
+     * Get the secret path.
+     *
+     * @return the secret path (may be empty for root listing)
+     */
+    public String getSecretPath() {
+        return secretPath;
+    }
+
+    @Override
+    public String toString() {
+        return "VaultPath{" +
+               "engineType='" + engineType + '\'' +
+               ", mountPath='" + mountPath + '\'' +
+               ", secretPath='" + secretPath + '\'' +
+               '}';
+    }
+}

--- a/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
@@ -8,6 +8,7 @@ package org.wildfly.security.hashicorp.vault._private;
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.TRACE;
+import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -280,4 +281,10 @@ public interface HashiCorpVaultLogger extends BasicLogger {
 
     @Message(id = 76, value = "Invalid default-engine-type configuration '%s'. Valid values are: KVv1, KVv2")
     CredentialStoreException invalidDefaultEngineType(String engineType);
+
+    // --- Deep nesting warning ---
+
+    @LogMessage(level = WARN)
+    @Message(id = 77, value = "Key path '%s' has deep nesting (%d levels). Consider flattening the JSON structure for better performance and maintainability.")
+    void deepKeyPathNesting(String keyPath, int nestingLevel);
 }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
@@ -274,4 +274,10 @@ public interface HashiCorpVaultLogger extends BasicLogger {
 
     @Message(id = 74, value = "Invalid alias format: %s. Expected format: [engine=TYPE][@mount-path][#]secret-path?key-path (# is optional when no engine= or @ prefix)")
     IllegalArgumentException invalidAliasFormat(String alias);
+
+    @Message(id = 75, value = "Invalid engine type '%s'. Valid values are: KVv1, KVv2")
+    IllegalArgumentException invalidEngineType(String engineType);
+
+    @Message(id = 76, value = "Invalid default-engine-type configuration '%s'. Valid values are: KVv1, KVv2")
+    CredentialStoreException invalidDefaultEngineType(String engineType);
 }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
@@ -262,4 +262,16 @@ public interface HashiCorpVaultLogger extends BasicLogger {
 
     @Message(id = 71, value = "Key path contains empty segment: %s")
     IllegalArgumentException keyPathContainsEmptySegment(String keyPath);
+
+    // --- Legacy format support ---
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 72, value = "Legacy alias format detected: '%s'. This format is deprecated and will be removed in a future release. Please migrate to the new format: '%s'")
+    void legacyAliasFormatDeprecated(String legacyAlias, String newFormatEquivalent);
+
+    @Message(id = 73, value = "Legacy alias format '%s' is not supported. Use new format: '%s'")
+    IllegalArgumentException legacyAliasFormatNotSupported(String legacyAlias, String newFormatEquivalent);
+
+    @Message(id = 74, value = "Invalid alias format: %s. Expected format: [engine=TYPE][@mount-path][#]secret-path?key-path (# is optional when no engine= or @ prefix)")
+    IllegalArgumentException invalidAliasFormat(String alias);
 }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
@@ -293,4 +293,7 @@ public interface HashiCorpVaultLogger extends BasicLogger {
 
     @Message(id = 79, value = "Could not list secrets at path '%s'")
     CredentialStoreException couldNotListSecretsAtPath(String path, @Cause Exception e);
+
+    @Message(id = 80, value = "Legacy path format '%s' is not supported when supportLegacyAliasFormat is disabled. Use '@mount#secretpath' or '#secretpath' format instead.")
+    CredentialStoreException legacyPathFormatNotSupported(String path);
 }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
@@ -227,4 +227,39 @@ public interface HashiCorpVaultLogger extends BasicLogger {
 
     @Message(id = 60, value = "No authentication method configured: provide either a vault token (via credential-reference) or TLS client certificate authentication (via authentication-context)")
     CredentialStoreException noAuthenticationMethodConfigured();
+
+    // --- Alias parsing errors ---
+
+    @Message(id = 61, value = "Alias cannot be null or empty")
+    IllegalArgumentException aliasCannotBeNullOrEmpty();
+
+    @Message(id = 62, value = "Invalid engine specification: missing delimiter after 'engine=' in alias: %s")
+    IllegalArgumentException invalidEngineSpecificationMissingDelimiter(String alias);
+
+    @Message(id = 63, value = "Engine type cannot be empty in alias: %s")
+    IllegalArgumentException engineTypeCannotBeEmpty(String alias);
+
+    @Message(id = 64, value = "Missing '#' delimiter after mount path in alias: %s")
+    IllegalArgumentException missingHashDelimiterAfterMountPath(String alias);
+
+    @Message(id = 65, value = "Mount path cannot be empty after '@' in alias: %s")
+    IllegalArgumentException mountPathCannotBeEmpty(String alias);
+
+    @Message(id = 66, value = "Secret path must start with '#' in alias: %s")
+    IllegalArgumentException secretPathMustStartWithHash(String alias);
+
+    @Message(id = 67, value = "Missing '?' delimiter before key path in alias: %s")
+    IllegalArgumentException missingQuestionDelimiterBeforeKeyPath(String alias);
+
+    @Message(id = 68, value = "Secret path cannot be empty in alias: %s")
+    IllegalArgumentException secretPathCannotBeEmpty(String alias);
+
+    @Message(id = 69, value = "Key path cannot be empty in alias: %s")
+    IllegalArgumentException keyPathCannotBeEmpty(String alias);
+
+    @Message(id = 70, value = "Key path cannot be null or empty")
+    IllegalArgumentException keyPathCannotBeNullOrEmpty();
+
+    @Message(id = 71, value = "Key path contains empty segment: %s")
+    IllegalArgumentException keyPathContainsEmptySegment(String keyPath);
 }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
@@ -143,43 +143,43 @@ public interface HashiCorpVaultLogger extends BasicLogger {
     @Message(id = 33, value = "Vault removed key %s from path %s successfully")
     void vaultRemovedKeyFromPath(String key, String path);
 
-    // --- Vault connector: VaultException message text (driver has no String+Throwable constructor) ---
+    // --- Vault connector: Exception methods (return proper exception types, not third-party VaultException) ---
 
     @Message(id = 34, value = "All login strategies failed")
-    String vaultAllLoginStrategiesFailed();
+    CredentialStoreException vaultAllLoginStrategiesFailed();
 
-    @Message(id = 35, value = "Path cannot be null or empty")
-    String vaultPathCannotBeNullOrEmpty();
+    @Message(id = 35, value = "Alias cannot be null")
+    IllegalArgumentException vaultAliasCannotBeNull();
 
     @Message(id = 36, value = "Key cannot be null or empty")
-    String vaultKeyCannotBeNullOrEmpty();
+    IllegalArgumentException vaultKeyCannotBeNullOrEmpty();
 
     @Message(id = 37, value = "Value cannot be null")
-    String vaultValueCannotBeNull();
+    IllegalArgumentException vaultValueCannotBeNull();
 
     @Message(id = 38, value = "Forbidden to retrieve secret at path: %s")
-    String vaultForbiddenToRetrieveSecretAtPath(String path);
+    CredentialStoreException vaultForbiddenToRetrieveSecretAtPath(String path);
 
     @Message(id = 39, value = "Failed to retrieve secret from path: %s/%s (HTTP %d)")
-    String vaultFailedToRetrieveSecretHttp(String path, String key, int responseStatus);
+    CredentialStoreException vaultFailedToRetrieveSecretHttp(String path, String key, int responseStatus);
 
     @Message(id = 40, value = "Forbidden to store secret at path: %s")
-    String vaultForbiddenToStoreSecretAtPath(String path);
+    CredentialStoreException vaultForbiddenToStoreSecretAtPath(String path);
 
     @Message(id = 41, value = "Failed to store secret at path: %s/%s (HTTP %d)")
-    String vaultFailedToStoreSecretHttp(String path, String key, int responseStatus);
+    CredentialStoreException vaultFailedToStoreSecretHttp(String path, String key, int responseStatus);
 
     @Message(id = 42, value = "Forbidden to delete secret at path: %s")
-    String vaultForbiddenToDeleteSecretAtPath(String path);
+    CredentialStoreException vaultForbiddenToDeleteSecretAtPath(String path);
 
     @Message(id = 43, value = "Failed to delete secret at path: %s (HTTP %d)")
-    String vaultFailedToDeleteSecretHttp(String path, int deleteStatus);
+    CredentialStoreException vaultFailedToDeleteSecretHttp(String path, int deleteStatus);
 
     @Message(id = 44, value = "Forbidden to update secret at path: %s")
-    String vaultForbiddenToUpdateSecretAtPath(String path);
+    CredentialStoreException vaultForbiddenToUpdateSecretAtPath(String path);
 
     @Message(id = 45, value = "Failed to update secret at path: %s after removing key %s (HTTP %d)")
-    String vaultFailedToUpdateSecretAfterRemoveKey(String path, String key, int writeStatus);
+    CredentialStoreException vaultFailedToUpdateSecretAfterRemoveKey(String path, String key, int writeStatus);
 
     @Message(id = 46, value = "Path does not exist or forbidden: \"%s\"")
     String vaultPathDoesNotExistOrForbidden(String path);
@@ -231,37 +231,37 @@ public interface HashiCorpVaultLogger extends BasicLogger {
     // --- Alias parsing errors ---
 
     @Message(id = 61, value = "Alias cannot be null or empty")
-    IllegalArgumentException aliasCannotBeNullOrEmpty();
+    CredentialStoreException aliasCannotBeNullOrEmpty();
 
     @Message(id = 62, value = "Invalid engine specification: missing delimiter after 'engine=' in alias: %s")
-    IllegalArgumentException invalidEngineSpecificationMissingDelimiter(String alias);
+    CredentialStoreException invalidEngineSpecificationMissingDelimiter(String alias);
 
     @Message(id = 63, value = "Engine type cannot be empty in alias: %s")
-    IllegalArgumentException engineTypeCannotBeEmpty(String alias);
+    CredentialStoreException engineTypeCannotBeEmpty(String alias);
 
     @Message(id = 64, value = "Missing '#' delimiter after mount path in alias: %s")
-    IllegalArgumentException missingHashDelimiterAfterMountPath(String alias);
+    CredentialStoreException missingHashDelimiterAfterMountPath(String alias);
 
     @Message(id = 65, value = "Mount path cannot be empty after '@' in alias: %s")
-    IllegalArgumentException mountPathCannotBeEmpty(String alias);
+    CredentialStoreException mountPathCannotBeEmpty(String alias);
 
     @Message(id = 66, value = "Secret path must start with '#' in alias: %s")
-    IllegalArgumentException secretPathMustStartWithHash(String alias);
+    CredentialStoreException secretPathMustStartWithHash(String alias);
 
     @Message(id = 67, value = "Missing '?' delimiter before key path in alias: %s")
-    IllegalArgumentException missingQuestionDelimiterBeforeKeyPath(String alias);
+    CredentialStoreException missingQuestionDelimiterBeforeKeyPath(String alias);
 
     @Message(id = 68, value = "Secret path cannot be empty in alias: %s")
-    IllegalArgumentException secretPathCannotBeEmpty(String alias);
+    CredentialStoreException secretPathCannotBeEmpty(String alias);
 
     @Message(id = 69, value = "Key path cannot be empty in alias: %s")
-    IllegalArgumentException keyPathCannotBeEmpty(String alias);
+    CredentialStoreException keyPathCannotBeEmpty(String alias);
 
     @Message(id = 70, value = "Key path cannot be null or empty")
-    IllegalArgumentException keyPathCannotBeNullOrEmpty();
+    CredentialStoreException keyPathCannotBeNullOrEmpty();
 
     @Message(id = 71, value = "Key path contains empty segment: %s")
-    IllegalArgumentException keyPathContainsEmptySegment(String keyPath);
+    CredentialStoreException keyPathContainsEmptySegment(String keyPath);
 
     // --- Legacy format support ---
 
@@ -270,13 +270,13 @@ public interface HashiCorpVaultLogger extends BasicLogger {
     void legacyAliasFormatDeprecated(String legacyAlias, String newFormatEquivalent);
 
     @Message(id = 73, value = "Legacy alias format '%s' is not supported. Use new format: '%s'")
-    IllegalArgumentException legacyAliasFormatNotSupported(String legacyAlias, String newFormatEquivalent);
+    CredentialStoreException legacyAliasFormatNotSupported(String legacyAlias, String newFormatEquivalent);
 
     @Message(id = 74, value = "Invalid alias format: %s. Expected format: [engine=TYPE][@mount-path][#]secret-path?key-path (# is optional when no engine= or @ prefix)")
-    IllegalArgumentException invalidAliasFormat(String alias);
+    CredentialStoreException invalidAliasFormat(String alias);
 
     @Message(id = 75, value = "Invalid engine type '%s'. Valid values are: KVv1, KVv2")
-    IllegalArgumentException invalidEngineType(String engineType);
+    CredentialStoreException invalidEngineType(String engineType);
 
     @Message(id = 76, value = "Invalid default-engine-type configuration '%s'. Valid values are: KVv1, KVv2")
     CredentialStoreException invalidDefaultEngineType(String engineType);

--- a/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/_private/HashiCorpVaultLogger.java
@@ -150,13 +150,13 @@ public interface HashiCorpVaultLogger extends BasicLogger {
     CredentialStoreException vaultAllLoginStrategiesFailed();
 
     @Message(id = 35, value = "Alias cannot be null")
-    IllegalArgumentException vaultAliasCannotBeNull();
+    CredentialStoreException vaultAliasCannotBeNull();
 
     @Message(id = 36, value = "Key cannot be null or empty")
-    IllegalArgumentException vaultKeyCannotBeNullOrEmpty();
+    CredentialStoreException vaultKeyCannotBeNullOrEmpty();
 
     @Message(id = 37, value = "Value cannot be null")
-    IllegalArgumentException vaultValueCannotBeNull();
+    CredentialStoreException vaultValueCannotBeNull();
 
     @Message(id = 38, value = "Forbidden to retrieve secret at path: %s")
     CredentialStoreException vaultForbiddenToRetrieveSecretAtPath(String path);
@@ -287,4 +287,10 @@ public interface HashiCorpVaultLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 77, value = "Key path '%s' has deep nesting (%d levels). Consider flattening the JSON structure for better performance and maintainability.")
     void deepKeyPathNesting(String keyPath, int nestingLevel);
+
+    @Message(id = 78, value = "Could not list secrets at path '%s' (HTTP status: %d)")
+    CredentialStoreException couldNotListSecretsAtPath(String path, int httpStatus);
+
+    @Message(id = 79, value = "Could not list secrets at path '%s'")
+    CredentialStoreException couldNotListSecretsAtPath(String path, @Cause Exception e);
 }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/loginstrategy/LoginContext.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/loginstrategy/LoginContext.java
@@ -4,8 +4,9 @@
  */
 package org.wildfly.security.hashicorp.vault.loginstrategy;
 
-import io.github.jopenlibs.vault.Vault;
 import org.wildfly.security.hashicorp.vault.JwtConfig;
+
+import io.github.jopenlibs.vault.Vault;
 
 /**
  * Current login context for the vault.

--- a/src/test/java/org/wildfly/security/hashicorp/vault/AliasFormatIntegrationTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/AliasFormatIntegrationTestCase.java
@@ -123,7 +123,7 @@ public class AliasFormatIntegrationTestCase {
                 "kv put secret/myapp/database password=secret123 db.host=localhost",
                 "kv put secret/my.app.config password=secret123 db.host=localhost",
                 "kv put secret/team.alpha/app.config password=secret123 db.host=localhost",
-                "kv put secret/test%20path password=secret123",
+                "kv put secret/\"test path\" password=secret123",
 
                 // Custom mount test data
                 "kv put custom/myapp password=secret123",
@@ -161,7 +161,7 @@ public class AliasFormatIntegrationTestCase {
                 "kv put secret/myapp/database password=secret123 db.host=localhost",
                 "kv put secret/my.app.config password=secret123 db.host=localhost",
                 "kv put secret/team.alpha/app.config password=secret123 db.host=localhost",
-                "kv put secret/test%20path password=secret123",
+                "kv put secret/\"test path\" password=secret123",
 
                 // Custom mount test data
                 "kv put custom/myapp password=secret123",
@@ -199,7 +199,7 @@ public class AliasFormatIntegrationTestCase {
                 // KV v2 test data
                 "kv put secret/myapp password=secret123 db.host=localhost",
                 "kv put secret/my.app password=secret123",
-                "kv put secret/test%20path password=secret123",
+                "kv put secret/\"test path\" password=secret123",
                 "kv put custom-v2/myapp password=secret123"
             );
     }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/AliasFormatIntegrationTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/AliasFormatIntegrationTestCase.java
@@ -15,7 +15,6 @@ import java.security.Provider;
 import java.security.spec.InvalidKeySpecException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
@@ -211,17 +210,6 @@ public class AliasFormatIntegrationTestCase {
             VaultContainer<?> container, KvVersion version, String mountPath, boolean supportLegacy) throws Exception {
 
         HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
-
-        // Set KV v1 fallback predicate for v1 configurations
-        if (version == KvVersion.V1) {
-            Predicate<String> kvV1Predicate = path ->
-                path.equals(mountPath) || path.startsWith(mountPath + "/") ||
-                path.equals("custom") || path.startsWith("custom/") ||
-                path.equals("custom-v1") || path.startsWith("custom-v1/") ||
-                path.equals("team/backend") || path.startsWith("team/backend/") ||
-                path.equals("team.alpha/backend") || path.startsWith("team.alpha/backend/");
-            store.setKvV1FallbackPredicate(kvV1Predicate);
-        }
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put("host-address", container.getHttpHostAddress());

--- a/src/test/java/org/wildfly/security/hashicorp/vault/AliasFormatIntegrationTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/AliasFormatIntegrationTestCase.java
@@ -1,0 +1,463 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.spec.InvalidKeySpecException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.vault.VaultContainer;
+import org.wildfly.security.auth.server.IdentityCredentials;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.store.CredentialStore;
+import org.wildfly.security.credential.store.CredentialStoreException;
+import org.wildfly.security.hashicorp.vault.KvVersionTestHelper.KvVersion;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+/**
+ * Comprehensive integration test suite for the new alias format implementation.
+ *
+ * <p>This test class validates the new alias format across multiple dimensions:
+ * <ul>
+ *   <li>KV Version Configurations (v1, v2, mixed)</li>
+ *   <li>Engine Path Complexity (default, custom, multi-part, with dots)</li>
+ *   <li>Secret Path Complexity (single, multi-part, with dots, URL-encoded)</li>
+ *   <li>Key Structure (simple, nested, with dots, mixed)</li>
+ *   <li>Backwards Compatibility (legacy format support)</li>
+ * </ul>
+ *
+ * <p><strong>Test Strategy:</strong>
+ * Uses container reuse strategy with one container per KV configuration to optimize
+ * execution time. All test data is pre-populated during container initialization.
+ *
+ * <p><strong>Test Coverage:</strong> ~90 integration tests covering:
+ * <ul>
+ *   <li>Core Coverage Tests: 40 tests</li>
+ *   <li>Interaction Tests: 25 tests</li>
+ *   <li>Edge Case Tests: 15 tests</li>
+ *   <li>Backwards Compatibility Tests: 10 tests</li>
+ * </ul>
+ *
+ * @see <a href="integration-test-matrix-design.md">Integration Test Matrix Design</a>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AliasFormatIntegrationTestCase {
+
+    private static final String DEFAULT_TOKEN = "myroot";
+
+    private VaultContainer<?> kvV1Container;
+    private VaultContainer<?> kvV2Container;
+    private VaultContainer<?> kvMixedContainer;
+
+    @BeforeAll
+    void setupContainers() {
+        // Initialize KV v1 container with comprehensive test data
+        kvV1Container = createKvV1Container();
+        kvV1Container.start();
+
+        // Initialize KV v2 container with comprehensive test data
+        kvV2Container = createKvV2Container();
+        kvV2Container.start();
+
+        // Initialize mixed KV container with comprehensive test data
+        kvMixedContainer = createKvMixedContainer();
+        kvMixedContainer.start();
+    }
+
+    @AfterAll
+    void teardownContainers() {
+        if (kvV1Container != null) {
+            kvV1Container.stop();
+        }
+        if (kvV2Container != null) {
+            kvV2Container.stop();
+        }
+        if (kvMixedContainer != null) {
+            kvMixedContainer.stop();
+        }
+    }
+
+    /**
+     * Creates a KV v1 container with all test data pre-populated.
+     */
+    private VaultContainer<?> createKvV1Container() {
+        return new VaultContainer<>("hashicorp/vault:1.13")
+            .withVaultToken(DEFAULT_TOKEN)
+            .withInitCommand(
+                // Disable default KV v2 and enable KV v1
+                "secrets disable secret",
+                "secrets enable -version=1 -path=secret kv",
+
+                // Enable custom mounts for engine path tests
+                "secrets enable -version=1 -path=custom kv",
+                "secrets enable -version=1 -path=team/backend kv",
+                "secrets enable -version=1 -path=team.alpha/backend kv",
+
+                // Standard test secret structure (supports all key path tests)
+                "kv put secret/myapp " +
+                    "password=secret123 " +
+                    "db.host=localhost",
+
+                // Multi-part secret paths
+                "kv put secret/myapp/database password=secret123 db.host=localhost",
+                "kv put secret/my.app.config password=secret123 db.host=localhost",
+                "kv put secret/team.alpha/app.config password=secret123 db.host=localhost",
+                "kv put secret/test%20path password=secret123",
+
+                // Custom mount test data
+                "kv put custom/myapp password=secret123",
+                "kv put team/backend/myapp password=secret123",
+                "kv put team.alpha/backend/myapp password=secret123",
+
+                // Edge case test data
+                "kv put secret/test#path password=secret123",
+                "kv put secret/test?path password=secret123",
+                "kv put secret/very/long/path/with/many/segments/secret password=secret123",
+                "kv put secret/a password=secret123"
+            );
+    }
+
+    /**
+     * Creates a KV v2 container with all test data pre-populated.
+     */
+    private VaultContainer<?> createKvV2Container() {
+        return new VaultContainer<>("hashicorp/vault:1.13")
+            .withVaultToken(DEFAULT_TOKEN)
+            .withInitCommand(
+                // KV v2 is enabled by default at secret/
+
+                // Enable custom mounts for engine path tests
+                "secrets enable -version=2 -path=custom kv",
+                "secrets enable -version=2 -path=team/backend kv",
+                "secrets enable -version=2 -path=team.alpha/backend kv",
+
+                // Standard test secret structure
+                "kv put secret/myapp " +
+                    "password=secret123 " +
+                    "db.host=localhost",
+
+                // Multi-part secret paths
+                "kv put secret/myapp/database password=secret123 db.host=localhost",
+                "kv put secret/my.app.config password=secret123 db.host=localhost",
+                "kv put secret/team.alpha/app.config password=secret123 db.host=localhost",
+                "kv put secret/test%20path password=secret123",
+
+                // Custom mount test data
+                "kv put custom/myapp password=secret123",
+                "kv put team/backend/myapp password=secret123",
+                "kv put team.alpha/backend/myapp password=secret123",
+
+                // Edge case test data
+                "kv put secret/test#path password=secret123",
+                "kv put secret/test?path password=secret123",
+                "kv put secret/very/long/path/with/many/segments/secret password=secret123",
+                "kv put secret/a password=secret123"
+            );
+    }
+
+    /**
+     * Creates a mixed KV container with both v1 and v2 engines at different mounts.
+     */
+    private VaultContainer<?> createKvMixedContainer() {
+        return new VaultContainer<>("hashicorp/vault:1.13")
+            .withVaultToken(DEFAULT_TOKEN)
+            .withInitCommand(
+                // Enable KV v1 at secret-v1/
+                "secrets enable -version=1 -path=secret-v1 kv",
+                // KV v2 is already enabled at secret/ by default
+
+                // Enable custom mounts
+                "secrets enable -version=1 -path=custom-v1 kv",
+                "secrets enable -version=2 -path=custom-v2 kv",
+
+                // KV v1 test data
+                "kv put secret-v1/myapp password=secret123 db.host=localhost",
+                "kv put secret-v1/myapp/db password=secret123",
+                "kv put custom-v1/myapp password=secret123",
+
+                // KV v2 test data
+                "kv put secret/myapp password=secret123 db.host=localhost",
+                "kv put secret/my.app password=secret123",
+                "kv put secret/test%20path password=secret123",
+                "kv put custom-v2/myapp password=secret123"
+            );
+    }
+
+    /**
+     * Creates a credential store configured for the specified container and KV version.
+     */
+    private HashicorpVaultCredentialStore createCredentialStore(
+            VaultContainer<?> container, KvVersion version, String mountPath, boolean supportLegacy) throws Exception {
+
+        HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
+
+        // Set KV v1 fallback predicate for v1 configurations
+        if (version == KvVersion.V1) {
+            Predicate<String> kvV1Predicate = path ->
+                path.equals(mountPath) || path.startsWith(mountPath + "/") ||
+                path.equals("custom") || path.startsWith("custom/") ||
+                path.equals("custom-v1") || path.startsWith("custom-v1/") ||
+                path.equals("team/backend") || path.startsWith("team/backend/") ||
+                path.equals("team.alpha/backend") || path.startsWith("team.alpha/backend/");
+            store.setKvV1FallbackPredicate(kvV1Predicate);
+        }
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("host-address", container.getHttpHostAddress());
+        attributes.put("namespace", "admin");
+
+        // Add legacy format support if requested
+        if (supportLegacy) {
+            attributes.put("support-legacy-alias-format", "true");
+        }
+
+        store.initialize(attributes,
+            new CredentialStore.CredentialSourceProtectionParameter(
+                IdentityCredentials.NONE.withCredential(createCredentialFromPassword(DEFAULT_TOKEN))),
+            new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
+
+        return store;
+    }
+
+    private PasswordCredential createCredentialFromPassword(String password)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR,
+            WildFlyElytronPasswordProvider.getInstance());
+        return new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec(password.toCharArray())));
+    }
+
+    // =====================================================================
+    // Category 1: Core Coverage Tests
+    // =====================================================================
+
+    /**
+     * Provides test configurations for KV version tests.
+     */
+    static Stream<Arguments> kvVersionTestCases() {
+        return Stream.of(
+            Arguments.of("KV-01", "KV v1 explicit", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1#myapp?password", "secret123", true, null, false),
+            Arguments.of("KV-02", "KV v2 explicit", "kvV2", KvVersion.V2, "secret",
+                "engine=KVv2#myapp?password", "secret123", true, null, false),
+            Arguments.of("KV-03", "Mixed v1 with mount", "kvMixed", KvVersion.V1, "secret-v1",
+                "engine=KVv1@secret-v1#myapp?password", "secret123", true, null, false)
+        );
+    }
+
+    @ParameterizedTest(name = "[{0}] {1}")
+    @MethodSource("kvVersionTestCases")
+    void testKvVersions(String testId, String description, String containerType, KvVersion version,
+                       String mountPath, String alias, String expectedValue, boolean shouldSucceed,
+                       String expectedErrorFragment, boolean supportLegacy) throws Exception {
+        executeTestCase(testId, containerType, version, mountPath, alias, expectedValue,
+                       shouldSucceed, expectedErrorFragment, supportLegacy);
+    }
+
+    /**
+     * Provides test configurations for engine path tests.
+     */
+    static Stream<Arguments> enginePathTestCases() {
+        return Stream.of(
+            // KV v1 engine paths
+            Arguments.of("EP-01", "v1 default mount", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1#myapp?password", "secret123", true, null, false),
+            Arguments.of("EP-02", "v1 single custom mount", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1@custom#myapp?password", "secret123", true, null, false),
+            Arguments.of("EP-03", "v1 multi-part mount", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1@team/backend#myapp?password", "secret123", true, null, false),
+            Arguments.of("EP-04", "v1 multi-part mount with dots", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1@team.alpha/backend#myapp?password", "secret123", true, null, false),
+
+            // KV v2 engine paths
+            Arguments.of("EP-05", "v2 default mount", "kvV2", KvVersion.V2, "secret",
+                "#myapp?password", "secret123", true, null, false),
+            Arguments.of("EP-06", "v2 single custom mount", "kvV2", KvVersion.V2, "secret",
+                "@custom#myapp?password", "secret123", true, null, false),
+            Arguments.of("EP-07", "v2 multi-part mount", "kvV2", KvVersion.V2, "secret",
+                "@team/backend#myapp?password", "secret123", true, null, false),
+            Arguments.of("EP-08", "v2 multi-part mount with dots", "kvV2", KvVersion.V2, "secret",
+                "@team.alpha/backend#myapp?password", "secret123", true, null, false),
+
+            // Mixed environment engine paths
+            Arguments.of("EP-09", "mixed v1 default", "kvMixed", KvVersion.V1, "secret-v1",
+                "engine=KVv1@secret-v1#myapp?password", "secret123", true, null, false),
+            Arguments.of("EP-10", "mixed v1 custom", "kvMixed", KvVersion.V1, "secret-v1",
+                "engine=KVv1@custom-v1#myapp?password", "secret123", true, null, false),
+            Arguments.of("EP-11", "mixed v2 default", "kvMixed", KvVersion.V2, "secret",
+                "engine=KVv2@secret#myapp?password", "secret123", true, null, false),
+            Arguments.of("EP-12", "mixed v2 custom", "kvMixed", KvVersion.V2, "secret",
+                "engine=KVv2@custom-v2#myapp?password", "secret123", true, null, false)
+        );
+    }
+
+    @ParameterizedTest(name = "[{0}] {1}")
+    @MethodSource("enginePathTestCases")
+    void testEnginePaths(String testId, String description, String containerType, KvVersion version,
+                        String mountPath, String alias, String expectedValue, boolean shouldSucceed,
+                        String expectedErrorFragment, boolean supportLegacy) throws Exception {
+        executeTestCase(testId, containerType, version, mountPath, alias, expectedValue,
+                       shouldSucceed, expectedErrorFragment, supportLegacy);
+    }
+
+    /**
+     * Provides test configurations for secret path tests.
+     */
+    static Stream<Arguments> secretPathTestCases() {
+        return Stream.of(
+            // KV v1 secret paths
+            Arguments.of("SP-01", "v1 single-part secret", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1#myapp?password", "secret123", true, null, false),
+            Arguments.of("SP-02", "v1 multi-part secret", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1#myapp/database?password", "secret123", true, null, false),
+            Arguments.of("SP-03", "v1 secret with dots", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1#my.app.config?password", "secret123", true, null, false),
+            Arguments.of("SP-04", "v1 multi-part with dots", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1#team.alpha/app.config?password", "secret123", true, null, false),
+            Arguments.of("SP-05", "v1 URL-encoded secret", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1#test%20path?password", "secret123", true, null, false),
+
+            // KV v2 secret paths
+            Arguments.of("SP-06", "v2 single-part secret", "kvV2", KvVersion.V2, "secret",
+                "#myapp?password", "secret123", true, null, false),
+            Arguments.of("SP-07", "v2 multi-part secret", "kvV2", KvVersion.V2, "secret",
+                "#myapp/database?password", "secret123", true, null, false),
+            Arguments.of("SP-08", "v2 secret with dots", "kvV2", KvVersion.V2, "secret",
+                "#my.app.config?password", "secret123", true, null, false),
+            Arguments.of("SP-09", "v2 multi-part with dots", "kvV2", KvVersion.V2, "secret",
+                "#team.alpha/app.config?password", "secret123", true, null, false),
+            Arguments.of("SP-10", "v2 URL-encoded secret", "kvV2", KvVersion.V2, "secret",
+                "#test%20path?password", "secret123", true, null, false),
+
+            // Mixed environment secret paths
+            Arguments.of("SP-11", "mixed v1 single-part", "kvMixed", KvVersion.V1, "secret-v1",
+                "engine=KVv1@secret-v1#myapp?password", "secret123", true, null, false),
+            Arguments.of("SP-12", "mixed v1 multi-part", "kvMixed", KvVersion.V1, "secret-v1",
+                "engine=KVv1@secret-v1#myapp/db?password", "secret123", true, null, false),
+            Arguments.of("SP-13", "mixed v2 single-part", "kvMixed", KvVersion.V2, "secret",
+                "engine=KVv2@secret#myapp?password", "secret123", true, null, false),
+            Arguments.of("SP-14", "mixed v2 with dots", "kvMixed", KvVersion.V2, "secret",
+                "engine=KVv2@secret#my.app?password", "secret123", true, null, false),
+            Arguments.of("SP-15", "mixed v2 URL-encoded", "kvMixed", KvVersion.V2, "secret",
+                "engine=KVv2@secret#test%20path?password", "secret123", true, null, false)
+        );
+    }
+
+    @ParameterizedTest(name = "[{0}] {1}")
+    @MethodSource("secretPathTestCases")
+    void testSecretPaths(String testId, String description, String containerType, KvVersion version,
+                        String mountPath, String alias, String expectedValue, boolean shouldSucceed,
+                        String expectedErrorFragment, boolean supportLegacy) throws Exception {
+        executeTestCase(testId, containerType, version, mountPath, alias, expectedValue,
+                       shouldSucceed, expectedErrorFragment, supportLegacy);
+    }
+
+    /**
+     * Provides test configurations for key structure tests.
+     */
+    static Stream<Arguments> keyStructureTestCases() {
+        return Stream.of(
+            // KV v1 key structures
+            Arguments.of("KS-01", "v1 simple key", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1#myapp?password", "secret123", true, null, false),
+            Arguments.of("KS-02", "v1 key with dots", "kvV1", KvVersion.V1, "secret",
+                "engine=KVv1#myapp?db.host", "localhost", true, null, false),
+
+            // KV v2 key structures
+            Arguments.of("KS-06", "v2 simple key", "kvV2", KvVersion.V2, "secret",
+                "#myapp?password", "secret123", true, null, false),
+            Arguments.of("KS-07", "v2 key with dots", "kvV2", KvVersion.V2, "secret",
+                "#myapp?db.host", "localhost", true, null, false)
+        );
+    }
+
+    @ParameterizedTest(name = "[{0}] {1}")
+    @MethodSource("keyStructureTestCases")
+    void testKeyStructures(String testId, String description, String containerType, KvVersion version,
+                          String mountPath, String alias, String expectedValue, boolean shouldSucceed,
+                          String expectedErrorFragment, boolean supportLegacy) throws Exception {
+        executeTestCase(testId, containerType, version, mountPath, alias, expectedValue,
+                       shouldSucceed, expectedErrorFragment, supportLegacy);
+    }
+
+    // =====================================================================
+    // Test Execution Helper
+    // =====================================================================
+
+    /**
+     * Executes a test case with proper assertions.
+     */
+    private void executeTestCase(String testId, String containerType, KvVersion version, String mountPath,
+                                 String alias, String expectedValue, boolean shouldSucceed,
+                                 String expectedErrorFragment, boolean supportLegacy) throws Exception {
+        VaultContainer<?> container;
+        switch (containerType) {
+            case "kvV1":
+                container = kvV1Container;
+                break;
+            case "kvV2":
+                container = kvV2Container;
+                break;
+            case "kvMixed":
+                container = kvMixedContainer;
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown container type: " + containerType);
+        }
+
+        HashicorpVaultCredentialStore store = createCredentialStore(container, version, mountPath, supportLegacy);
+
+        if (shouldSucceed) {
+            PasswordCredential credential = store.retrieve(
+                alias,
+                PasswordCredential.class,
+                ClearPassword.ALGORITHM_CLEAR,
+                null,
+                null);
+
+            if (expectedValue == null) {
+                assertNull(credential,
+                    String.format("[%s] Expected null credential", testId));
+            } else {
+                assertNotNull(credential,
+                    String.format("[%s] Should retrieve credential", testId));
+                String actualPassword = new String(
+                    credential.getPassword().castAndApply(ClearPassword.class, ClearPassword::getPassword));
+                assertEquals(expectedValue, actualPassword,
+                    String.format("[%s] Password should match", testId));
+            }
+        } else {
+            CredentialStoreException exception = assertThrows(
+                CredentialStoreException.class,
+                () -> store.retrieve(alias, PasswordCredential.class,
+                    ClearPassword.ALGORITHM_CLEAR, null, null),
+                String.format("[%s] Should throw CredentialStoreException", testId));
+
+            if (expectedErrorFragment != null) {
+                assertTrue(exception.getMessage().contains(expectedErrorFragment),
+                    String.format("[%s] Error message should contain '%s', but was: %s",
+                        testId, expectedErrorFragment, exception.getMessage()));
+            }
+        }
+    }
+}

--- a/src/test/java/org/wildfly/security/hashicorp/vault/BackwardsCompatibilityTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/BackwardsCompatibilityTestCase.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.spec.InvalidKeySpecException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.vault.VaultContainer;
+import org.wildfly.security.auth.server.IdentityCredentials;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.store.CredentialStore;
+import org.wildfly.security.credential.store.CredentialStoreException;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+/**
+ * Integration test suite for backwards compatibility with legacy alias format.
+ *
+ * <p>This test class validates:
+ * <ul>
+ *   <li>Legacy format support when enabled via configuration</li>
+ *   <li>Legacy format rejection when disabled</li>
+ *   <li>Deprecation warnings for legacy format usage</li>
+ *   <li>Migration path from legacy to new format</li>
+ *   <li>Coexistence of legacy and new formats</li>
+ *   <li>Existing configuration compatibility</li>
+ * </ul>
+ *
+ * <p><strong>Test Scenarios:</strong>
+ * <ol>
+ *   <li>Legacy format with support enabled - verify it works with deprecation warnings</li>
+ *   <li>Legacy format with support disabled - verify rejection with helpful error</li>
+ *   <li>Mixed usage - verify both formats can coexist when legacy support enabled</li>
+ *   <li>Migration scenarios - verify gradual migration path</li>
+ *   <li>Existing configurations - verify no breaking changes</li>
+ * </ol>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class BackwardsCompatibilityTestCase {
+
+    private static final String DEFAULT_TOKEN = "myroot";
+    private static final String TEST_PASSWORD = "secretPassword123";
+
+    private VaultContainer<?> kvV2Container;
+
+    @BeforeAll
+    void setupContainer() {
+        // Create KV v2 container with test data
+        kvV2Container = new VaultContainerKvV1("hashicorp/vault:1.13", DEFAULT_TOKEN)
+            .withInitCommand(
+                // Disable default KV v2 at secret/
+                "secrets disable secret",
+                // Enable KV v2 at secret/ mount point
+                "secrets enable -version=2 -path=secret kv",
+                // Add test data for legacy format tests
+                "kv put secret/myapp/db password=" + TEST_PASSWORD,
+                "kv put secret/app.config dbpass=pass123 apikey=key456",
+                "kv put secret/my.app.db password=dbpass789",
+                "kv put secret/legacy/test value=legacy123",
+                // Add test data for new format tests
+                "kv put secret/newformat/test password=new456"
+            );
+        kvV2Container.start();
+    }
+
+    @AfterAll
+    void teardownContainer() {
+        if (kvV2Container != null) {
+            kvV2Container.stop();
+        }
+    }
+
+    /**
+     * Test 1: Legacy format with support enabled.
+     * Verify that legacy format works and deprecation warnings are logged.
+     */
+    @Test
+    void testLegacyFormatWithSupportEnabled() throws Exception {
+        Map<String, String> attributes = createBaseAttributes();
+        attributes.put("support-legacy-alias-format", "true");
+
+        HashicorpVaultCredentialStore store = createAndInitializeStore(attributes);
+
+        // Test simple legacy format: myapp/db.password
+        String legacyAlias = "myapp/db.password";
+        PasswordCredential credential = store.retrieve(legacyAlias, PasswordCredential.class, null, null, null);
+
+        assertNotNull(credential, "Should retrieve credential using legacy format");
+        assertEquals(TEST_PASSWORD, new String(credential.getPassword().castAndApply(ClearPassword.class, ClearPassword::getPassword)));
+    }
+
+    /**
+     * Test 2: Legacy format with support disabled.
+     * Verify that legacy format is rejected with helpful error message.
+     */
+    @Test
+    void testLegacyFormatWithSupportDisabled() throws Exception {
+        Map<String, String> attributes = createBaseAttributes();
+        attributes.put("support-legacy-alias-format", "false");
+
+        HashicorpVaultCredentialStore store = createAndInitializeStore(attributes);
+
+        // Test that legacy format is rejected
+        String legacyAlias = "myapp/db.password";
+        CredentialStoreException exception = assertThrows(
+            CredentialStoreException.class,
+            () -> store.retrieve(legacyAlias, PasswordCredential.class, null, null, null),
+            "Should reject legacy format when support disabled"
+        );
+
+        // Verify error message includes equivalent new format
+        String errorMessage = exception.getMessage();
+        assertTrue(errorMessage.contains("not supported"), "Error should mention format not supported");
+        assertTrue(errorMessage.contains("myapp/db?password") || errorMessage.contains("#myapp/db?password"),
+            "Error should include equivalent new format");
+    }
+
+    /**
+     * Test 3: Legacy format with support disabled by default.
+     * Verify that legacy format support defaults to false.
+     */
+    @Test
+    void testLegacyFormatDefaultDisabled() throws Exception {
+        Map<String, String> attributes = createBaseAttributes();
+        // Don't set support-legacy-alias-format - should default to false
+
+        HashicorpVaultCredentialStore store = createAndInitializeStore(attributes);
+
+        // Test that legacy format is rejected by default
+        String legacyAlias = "myapp/db.password";
+        assertThrows(
+            CredentialStoreException.class,
+            () -> store.retrieve(legacyAlias, PasswordCredential.class, null, null, null),
+            "Should reject legacy format by default"
+        );
+    }
+
+    /**
+     * Test 4: Mixed usage - legacy and new format coexistence.
+     * Verify both formats work when legacy support is enabled.
+     */
+    @Test
+    void testMixedFormatUsage() throws Exception {
+        Map<String, String> attributes = createBaseAttributes();
+        attributes.put("support-legacy-alias-format", "true");
+
+        HashicorpVaultCredentialStore store = createAndInitializeStore(attributes);
+
+        // Test legacy format
+        String legacyAlias = "myapp/db.password";
+        PasswordCredential legacyCredential = store.retrieve(legacyAlias, PasswordCredential.class, null, null, null);
+        assertNotNull(legacyCredential, "Should retrieve using legacy format");
+
+        // Test new format for the same secret
+        String newAlias = "#myapp/db?password";
+        PasswordCredential newCredential = store.retrieve(newAlias, PasswordCredential.class, null, null, null);
+        assertNotNull(newCredential, "Should retrieve using new format");
+
+        // Verify both retrieve the same value
+        String legacyPassword = new String(legacyCredential.getPassword().castAndApply(ClearPassword.class, ClearPassword::getPassword));
+        String newPassword = new String(newCredential.getPassword().castAndApply(ClearPassword.class, ClearPassword::getPassword));
+        assertEquals(legacyPassword, newPassword, "Both formats should retrieve same credential");
+    }
+
+    /**
+     * Test 5: Legacy format with dots in secret path.
+     * Verify that dots in secret path are handled correctly (split on LAST dot).
+     */
+    @Test
+    void testLegacyFormatWithDotsInSecretPath() throws Exception {
+        Map<String, String> attributes = createBaseAttributes();
+        attributes.put("support-legacy-alias-format", "true");
+
+        HashicorpVaultCredentialStore store = createAndInitializeStore(attributes);
+
+        // Legacy format: app.config.dbpass (should split as "app.config" and "dbpass")
+        String legacyAlias = "app.config.dbpass";
+        PasswordCredential credential = store.retrieve(legacyAlias, PasswordCredential.class, null, null, null);
+
+        assertNotNull(credential, "Should retrieve credential with dots in secret path");
+        assertEquals("pass123", new String(credential.getPassword().castAndApply(ClearPassword.class, ClearPassword::getPassword)));
+    }
+
+    /**
+     * Test 6: Legacy format with multiple dots.
+     * Verify correct handling when both secret path and key have dots.
+     */
+    @Test
+    void testLegacyFormatWithMultipleDots() throws Exception {
+        Map<String, String> attributes = createBaseAttributes();
+        attributes.put("support-legacy-alias-format", "true");
+
+        HashicorpVaultCredentialStore store = createAndInitializeStore(attributes);
+
+        // Legacy format: my.app.db.password (should split as "my.app.db" and "password")
+        String legacyAlias = "my.app.db.password";
+        PasswordCredential credential = store.retrieve(legacyAlias, PasswordCredential.class, null, null, null);
+
+        assertNotNull(credential, "Should retrieve credential with multiple dots");
+        assertEquals("dbpass789", new String(credential.getPassword().castAndApply(ClearPassword.class, ClearPassword::getPassword)));
+    }
+
+    /**
+     * Test 7: Migration scenario - gradual migration.
+     * Verify that applications can migrate gradually from legacy to new format.
+     */
+    @Test
+    void testGradualMigration() throws Exception {
+        Map<String, String> attributes = createBaseAttributes();
+        attributes.put("support-legacy-alias-format", "true");
+
+        HashicorpVaultCredentialStore store = createAndInitializeStore(attributes);
+
+        // Step 1: Use legacy format (existing configuration)
+        String legacyAlias = "legacy/test.value";
+        PasswordCredential legacyCredential = store.retrieve(legacyAlias, PasswordCredential.class, null, null, null);
+        assertNotNull(legacyCredential, "Legacy format should work during migration");
+
+        // Step 2: Use new format (migrated configuration)
+        String newAlias = "#newformat/test?password";
+        PasswordCredential newCredential = store.retrieve(newAlias, PasswordCredential.class, null, null, null);
+        assertNotNull(newCredential, "New format should work during migration");
+
+        // Both should work simultaneously during migration period
+        assertNotNull(legacyCredential, "Legacy format should continue working");
+        assertNotNull(newCredential, "New format should work alongside legacy");
+    }
+
+    /**
+     * Test 8: Existing configuration compatibility.
+     * Verify that existing credential stores continue to work without changes.
+     */
+    @Test
+    void testExistingConfigurationCompatibility() throws Exception {
+        // Test with minimal configuration (as existing deployments might have)
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("host-address", kvV2Container.getHttpHostAddress());
+
+        HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
+
+        char[] token = DEFAULT_TOKEN.toCharArray();
+        CredentialStore.CredentialSourceProtectionParameter protectionParameter =
+            new CredentialStore.CredentialSourceProtectionParameter(
+                IdentityCredentials.NONE.withCredential(
+                    createPasswordCredential(token)
+                )
+            );
+
+        store.initialize(attributes, protectionParameter, new Provider[]{new WildFlyElytronPasswordProvider()});
+
+        // Verify new format works (existing configs using new format should continue working)
+        String newAlias = "#myapp/db?password";
+        PasswordCredential credential = store.retrieve(newAlias, PasswordCredential.class, null, null, null);
+        assertNotNull(credential, "Existing configurations with new format should work");
+    }
+
+    /**
+     * Test 9: Legacy format error message quality.
+     * Verify that error messages provide clear migration guidance.
+     */
+    @Test
+    void testLegacyFormatErrorMessageQuality() throws Exception {
+        Map<String, String> attributes = createBaseAttributes();
+        attributes.put("support-legacy-alias-format", "false");
+
+        HashicorpVaultCredentialStore store = createAndInitializeStore(attributes);
+
+        // Test various legacy formats to ensure error messages are helpful
+        String[] legacyAliases = {
+            "simple.key",
+            "path/to/secret.key",
+            "app.config.dbpass"
+        };
+
+        for (String legacyAlias : legacyAliases) {
+            CredentialStoreException exception = assertThrows(
+                CredentialStoreException.class,
+                () -> store.retrieve(legacyAlias, PasswordCredential.class, null, null, null),
+                "Should reject legacy format: " + legacyAlias
+            );
+
+            String errorMessage = exception.getMessage();
+            assertTrue(errorMessage.contains(legacyAlias),
+                "Error should mention the problematic alias: " + legacyAlias);
+            assertTrue(errorMessage.contains("?") || errorMessage.contains("#"),
+                "Error should show new format syntax for: " + legacyAlias);
+        }
+    }
+
+    /**
+     * Test 10: Cache behavior with legacy format.
+     * Verify that credential caching works correctly with legacy format.
+     */
+    @Test
+    void testLegacyFormatCacheBehavior() throws Exception {
+        Map<String, String> attributes = createBaseAttributes();
+        attributes.put("support-legacy-alias-format", "true");
+
+        HashicorpVaultCredentialStore store = createAndInitializeStore(attributes);
+
+        String legacyAlias = "myapp/db.password";
+
+        // First retrieval - should fetch from Vault
+        PasswordCredential credential1 = store.retrieve(legacyAlias, PasswordCredential.class, null, null, null);
+        assertNotNull(credential1, "First retrieval should succeed");
+
+        // Second retrieval - should use cache
+        PasswordCredential credential2 = store.retrieve(legacyAlias, PasswordCredential.class, null, null, null);
+        assertNotNull(credential2, "Second retrieval should succeed (from cache)");
+
+        // Verify both return the same value
+        String password1 = new String(credential1.getPassword().castAndApply(ClearPassword.class, ClearPassword::getPassword));
+        String password2 = new String(credential2.getPassword().castAndApply(ClearPassword.class, ClearPassword::getPassword));
+        assertEquals(password1, password2, "Cached credential should match original");
+    }
+
+    // Helper methods
+
+    private Map<String, String> createBaseAttributes() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("host-address", kvV2Container.getHttpHostAddress());
+        return attributes;
+    }
+
+    private HashicorpVaultCredentialStore createAndInitializeStore(Map<String, String> attributes) throws Exception {
+        HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
+
+        char[] token = DEFAULT_TOKEN.toCharArray();
+        CredentialStore.CredentialSourceProtectionParameter protectionParameter =
+            new CredentialStore.CredentialSourceProtectionParameter(
+                IdentityCredentials.NONE.withCredential(
+                    createPasswordCredential(token)
+                )
+            );
+
+        store.initialize(attributes, protectionParameter, new Provider[]{new WildFlyElytronPasswordProvider()});
+        return store;
+    }
+
+    private PasswordCredential createPasswordCredential(char[] password)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR,
+            new WildFlyElytronPasswordProvider());
+        return new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec(password)));
+    }
+}

--- a/src/test/java/org/wildfly/security/hashicorp/vault/ClientTLSAuthenticationWithHttpClientTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/ClientTLSAuthenticationWithHttpClientTestCase.java
@@ -7,11 +7,14 @@ package org.wildfly.security.hashicorp.vault;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.Map;
+
 import javax.net.ssl.SSLContext;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.wildfly.security.credential.store.CredentialStoreException;
 
 import io.github.jopenlibs.vault.SslConfig;
 import io.github.jopenlibs.vault.VaultException;
@@ -50,10 +53,44 @@ public class ClientTLSAuthenticationWithHttpClientTestCase {
     }
 
     /**
+     * Helper method to get a secret value using the new alias-based API.
+     */
+    private String getSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        Map<String, Object> data = connector.getSecretData(alias);
+        if (data == null) {
+            return null;
+        }
+        return KeyPathResolver.resolveKeyPath(data, key);
+    }
+
+    /**
+     * Helper method to put a secret value using the new alias-based API.
+     */
+    private void putSecret(VaultConnector connector, String path, String key, String value) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        connector.putSecretData(alias, value);
+    }
+
+    /**
+     * Helper method to remove a secret value using the new alias-based API.
+     */
+    private void removeSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        connector.removeSecretData(alias);
+    }
+
+    /**
      * VaultConnector with SSLContext, test get secret over HTTPS
      */
     @Test
-    public void testGetSecretWithHttpClientSslContext() throws VaultException {
+    public void testGetSecretWithHttpClientSslContext() throws Exception {
         SslConfig sslConfig = new SslConfig().verify(true).build();
         VaultConnector connector = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(),
@@ -63,14 +100,14 @@ public class ClientTLSAuthenticationWithHttpClientTestCase {
                 true,
                 sslContext);
         connector.configure();
-        assertEquals("password123", connector.getSecret("secret/testing1", "top_secret"));
+        assertEquals("password123", getSecret(connector, "secret/testing1", "top_secret"));
     }
 
     /**
      * VaultConnector with SSLContext, test put secret over HTTPS
      */
     @Test
-    public void testPutSecretWithHttpClientSslContext() throws VaultException {
+    public void testPutSecretWithHttpClientSslContext() throws Exception {
         SslConfig sslConfig = new SslConfig().verify(true).build();
         VaultConnector connector = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(),
@@ -80,15 +117,15 @@ public class ClientTLSAuthenticationWithHttpClientTestCase {
                 true,
                 sslContext);
         connector.configure();
-        connector.putSecret("secret/testing1", "top_secret2", "password2");
-        assertEquals("password2", connector.getSecret("secret/testing1", "top_secret2"));
+        putSecret(connector, "secret/testing1", "top_secret2", "password2");
+        assertEquals("password2", getSecret(connector, "secret/testing1", "top_secret2"));
     }
 
     /**
      * VaultConnector with SSLContext, test remove secret over HTTPS
      */
     @Test
-    public void testRemoveSecretWithHttpClientSslContext() throws VaultException {
+    public void testRemoveSecretWithHttpClientSslContext() throws Exception {
         SslConfig sslConfig = new SslConfig().verify(true).build();
         VaultConnector connector = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(),
@@ -98,8 +135,8 @@ public class ClientTLSAuthenticationWithHttpClientTestCase {
                 true,
                 sslContext);
         connector.configure();
-        assertEquals("password123", connector.getSecret("secret/testing1", "top_secret"));
-        connector.removeSecret("secret/testing1", "top_secret");
-        assertNull(connector.getSecret("secret/testing1", "top_secret"));
+        assertEquals("password123", getSecret(connector, "secret/testing1", "top_secret"));
+        removeSecret(connector, "secret/testing1", "top_secret");
+        assertNull(getSecret(connector, "secret/testing1", "top_secret"));
     }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/ClientTLSAuthenticationWithHttpClientTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/ClientTLSAuthenticationWithHttpClientTestCase.java
@@ -4,16 +4,17 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.VaultException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import javax.net.ssl.SSLContext;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.net.ssl.SSLContext;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
 
 /**
  * Tests that {@link VaultConnector} works over HTTPS when an SSLContext is passed.

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreKvVersionTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreKvVersionTestCase.java
@@ -16,6 +16,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -88,8 +89,15 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         );
     }
 
-    private HashicorpVaultCredentialStore createCredentialStore(VaultContainer<?> container) throws Exception {
+    private HashicorpVaultCredentialStore createCredentialStore(VaultContainer<?> container, KvVersion version, String mountPath) throws Exception {
         HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
+
+        // Set the KV v1 fallback predicate before initialization
+        if (version == KvVersion.V1) {
+            Predicate<String> kvV1Predicate = path -> path.equals(mountPath) || path.startsWith(mountPath + "/");
+            store.setKvV1FallbackPredicate(kvV1Predicate);
+        }
+
         Map<String, String> attributes = new HashMap<>();
         attributes.put("host-address", container.getHttpHostAddress());
         attributes.put("namespace", "admin");
@@ -123,7 +131,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
         PasswordCredential credential = store.retrieve(
             mountPath + "/testing1.top_secret",
             PasswordCredential.class,
@@ -142,7 +150,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Store a new credential
         store.store(mountPath + "/testing1.test_secret", createCredentialFromPassword("testPassword"), null);
@@ -166,7 +174,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Store two credentials at the same path
         store.store(mountPath + "/myapp.mp", createCredentialFromPassword("password1"), null);
@@ -196,7 +204,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Store two credentials
         store.store(mountPath + "/myapp.mp", createCredentialFromPassword("password1"), null);
@@ -235,7 +243,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         Set<String> aliases = store.getAliases(mountPath + "/testing1");
         assertNotNull(aliases, String.format("Should return aliases in %s", version));
@@ -254,7 +262,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Get aliases from testing1
         Set<String> aliases1 = store.getAliases(mountPath + "/testing1");
@@ -274,7 +282,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         Set<String> aliases1 = store.getAliases(mountPath + "/testing1");
         Set<String> aliases2 = store.getAliases(mountPath + "/testing1", false, 0);
@@ -290,7 +298,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Create nested structure
         store.store(mountPath + "/app1.key1", createCredentialFromPassword("value1"), null);
@@ -313,7 +321,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Create nested structure
         store.store(mountPath + "/app1.key1", createCredentialFromPassword("value1"), null);
@@ -336,7 +344,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Create multiple subpaths at same level
         store.store(mountPath + "/app1.key1", createCredentialFromPassword("value1"), null);

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreKvVersionTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreKvVersionTestCase.java
@@ -16,7 +16,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -91,16 +90,6 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
 
     private HashicorpVaultCredentialStore createCredentialStore(VaultContainer<?> container, KvVersion version, String mountPath) throws Exception {
         HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
-
-        // Note: kvV1FallbackPredicate is a temporary mechanism that will be removed.
-        // For pure KV v1 environments, set the predicate to identify the v1 mount.
-        // For mixed environments, tests should use explicit engine= in alias strings instead.
-        if (version == KvVersion.V1 && !(container instanceof VaultContainerKvMixed)) {
-            // Pure KV v1 environment only
-            Predicate<String> kvV1Predicate = path ->
-                path.equals(mountPath) || path.startsWith(mountPath + "/");
-            store.setKvV1FallbackPredicate(kvV1Predicate);
-        }
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put("host-address", container.getHttpHostAddress());

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreKvVersionTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreKvVersionTestCase.java
@@ -92,15 +92,23 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
     private HashicorpVaultCredentialStore createCredentialStore(VaultContainer<?> container, KvVersion version, String mountPath) throws Exception {
         HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
 
-        // Set the KV v1 fallback predicate before initialization
-        if (version == KvVersion.V1) {
-            Predicate<String> kvV1Predicate = path -> path.equals(mountPath) || path.startsWith(mountPath + "/");
+        // Note: kvV1FallbackPredicate is a temporary mechanism that will be removed.
+        // For pure KV v1 environments, set the predicate to identify the v1 mount.
+        // For mixed environments, tests should use explicit engine= in alias strings instead.
+        if (version == KvVersion.V1 && !(container instanceof VaultContainerKvMixed)) {
+            // Pure KV v1 environment only
+            Predicate<String> kvV1Predicate = path ->
+                path.equals(mountPath) || path.startsWith(mountPath + "/");
             store.setKvV1FallbackPredicate(kvV1Predicate);
         }
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put("host-address", container.getHttpHostAddress());
         attributes.put("namespace", "admin");
+        // Set default engine type based on the KV version being tested
+        String engineType = version == KvVersion.V1 ? "KVv1" : "KVv2";
+        attributes.put("default-engine-type", engineType);
+        attributes.put("default-mount-path", mountPath);
         store.initialize(attributes,
             new CredentialStore.CredentialSourceProtectionParameter(
                 IdentityCredentials.NONE.withCredential(createCredentialFromPassword("myroot"))),
@@ -133,7 +141,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
 
         HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
         PasswordCredential credential = store.retrieve(
-            mountPath + "/testing1.top_secret",
+            "#testing1?top_secret",
             PasswordCredential.class,
             ClearPassword.ALGORITHM_CLEAR,
             null,
@@ -153,11 +161,11 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Store a new credential
-        store.store(mountPath + "/testing1.test_secret", createCredentialFromPassword("testPassword"), null);
+        store.store("#testing1?test_secret", createCredentialFromPassword("testPassword"), null);
 
         // Retrieve and verify
         PasswordCredential credential = store.retrieve(
-            mountPath + "/testing1.test_secret",
+            "#testing1?test_secret",
             PasswordCredential.class,
             ClearPassword.ALGORITHM_CLEAR,
             null,
@@ -177,12 +185,12 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Store two credentials at the same path
-        store.store(mountPath + "/myapp.mp", createCredentialFromPassword("password1"), null);
-        store.store(mountPath + "/myapp.mp2", createCredentialFromPassword("password2"), null);
+        store.store("#myapp?mp", createCredentialFromPassword("password1"), null);
+        store.store("#myapp?mp2", createCredentialFromPassword("password2"), null);
 
         // Verify both exist
         PasswordCredential credential1 = store.retrieve(
-            mountPath + "/myapp.mp",
+            "#myapp?mp",
             PasswordCredential.class,
             ClearPassword.ALGORITHM_CLEAR,
             null,
@@ -190,7 +198,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         assertNotNull(credential1, String.format("First credential should exist in %s", version));
 
         PasswordCredential credential2 = store.retrieve(
-            mountPath + "/myapp.mp2",
+            "#myapp?mp2",
             PasswordCredential.class,
             ClearPassword.ALGORITHM_CLEAR,
             null,
@@ -207,15 +215,15 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Store two credentials
-        store.store(mountPath + "/myapp.mp", createCredentialFromPassword("password1"), null);
-        store.store(mountPath + "/myapp.mp2", createCredentialFromPassword("password2"), null);
+        store.store("#myapp?mp", createCredentialFromPassword("password1"), null);
+        store.store("#myapp?mp2", createCredentialFromPassword("password2"), null);
 
         // Remove one
-        store.remove(mountPath + "/myapp.mp2", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null);
+        store.remove("#myapp?mp2", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null);
 
         // Verify first still exists
         PasswordCredential remaining = store.retrieve(
-            mountPath + "/myapp.mp",
+            "#myapp?mp",
             PasswordCredential.class,
             ClearPassword.ALGORITHM_CLEAR,
             null,
@@ -225,7 +233,7 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
 
         // Verify second is gone
         PasswordCredential removed = store.retrieve(
-            mountPath + "/myapp.mp2",
+            "#myapp?mp2",
             PasswordCredential.class,
             ClearPassword.ALGORITHM_CLEAR,
             null,
@@ -245,14 +253,14 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
 
         HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
-        Set<String> aliases = store.getAliases(mountPath + "/testing1");
+        Set<String> aliases = store.getAliases("#testing1");
         assertNotNull(aliases, String.format("Should return aliases in %s", version));
         assertFalse(aliases.isEmpty(), String.format("Should have aliases in %s", version));
-        assertTrue(aliases.contains(mountPath + "/testing1.top_secret"),
+        assertTrue(aliases.contains("#testing1?top_secret"),
             String.format("Should contain expected alias in %s", version));
 
         // Verify it doesn't contain aliases from other paths
-        assertFalse(aliases.contains(mountPath + "/testing2.dbuser"),
+        assertFalse(aliases.contains("#testing2?dbuser"),
             String.format("Should not contain aliases from other paths in %s", version));
     }
 
@@ -265,15 +273,15 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Get aliases from testing1
-        Set<String> aliases1 = store.getAliases(mountPath + "/testing1");
-        assertTrue(aliases1.contains(mountPath + "/testing1.top_secret"));
-        assertFalse(aliases1.contains(mountPath + "/testing2.dbuser"));
+        Set<String> aliases1 = store.getAliases("#testing1");
+        assertTrue(aliases1.contains("#testing1?top_secret"));
+        assertFalse(aliases1.contains("#testing2?dbuser"));
 
         // Get aliases from testing2
-        Set<String> aliases2 = store.getAliases(mountPath + "/testing2");
-        assertTrue(aliases2.contains(mountPath + "/testing2.dbuser"));
-        assertTrue(aliases2.contains(mountPath + "/testing2.jmsuser"));
-        assertFalse(aliases2.contains(mountPath + "/testing1.top_secret"));
+        Set<String> aliases2 = store.getAliases("#testing2");
+        assertTrue(aliases2.contains("#testing2?dbuser"));
+        assertTrue(aliases2.contains("#testing2?jmsuser"));
+        assertFalse(aliases2.contains("#testing1?top_secret"));
     }
 
     @ParameterizedTest(name = "[{2}] Get aliases non-recursive at {1}")
@@ -284,12 +292,12 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
 
         HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
-        Set<String> aliases1 = store.getAliases(mountPath + "/testing1");
-        Set<String> aliases2 = store.getAliases(mountPath + "/testing1", false, 0);
+        Set<String> aliases1 = store.getAliases("#testing1");
+        Set<String> aliases2 = store.getAliases("#testing1", false, 0);
 
         assertEquals(aliases1, aliases2,
             String.format("Non-recursive should match default behavior in %s", version));
-        assertTrue(aliases2.contains(mountPath + "/testing1.top_secret"));
+        assertTrue(aliases2.contains("#testing1?top_secret"));
     }
 
     @ParameterizedTest(name = "[{2}] Get aliases recursive depth 0 at {1}")
@@ -301,17 +309,17 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Create nested structure
-        store.store(mountPath + "/app1.key1", createCredentialFromPassword("value1"), null);
-        store.store(mountPath + "/app1.key2", createCredentialFromPassword("value2"), null);
-        store.store(mountPath + "/app1/subapp.key3", createCredentialFromPassword("value3"), null);
+        store.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        store.store("#app1?key2", createCredentialFromPassword("value2"), null);
+        store.store("#app1/subapp?key3", createCredentialFromPassword("value3"), null);
 
-        Set<String> aliases = store.getAliases(mountPath + "/app1", true, 0);
+        Set<String> aliases = store.getAliases("#app1", true, 0);
 
-        assertTrue(aliases.contains(mountPath + "/app1.key1"),
+        assertTrue(aliases.contains("#app1?key1"),
             String.format("Should contain top-level key1 in %s", version));
-        assertTrue(aliases.contains(mountPath + "/app1.key2"),
+        assertTrue(aliases.contains("#app1?key2"),
             String.format("Should contain top-level key2 in %s", version));
-        assertFalse(aliases.contains(mountPath + "/app1/subapp.key3"),
+        assertFalse(aliases.contains("#app1/subapp?key3"),
             String.format("Should not include nested keys at depth 0 in %s", version));
     }
 
@@ -324,17 +332,17 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Create nested structure
-        store.store(mountPath + "/app1.key1", createCredentialFromPassword("value1"), null);
-        store.store(mountPath + "/app1/subapp1.key2", createCredentialFromPassword("value2"), null);
-        store.store(mountPath + "/app1/subapp1/deep.key3", createCredentialFromPassword("value3"), null);
+        store.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        store.store("#app1/subapp1?key2", createCredentialFromPassword("value2"), null);
+        store.store("#app1/subapp1/deep?key3", createCredentialFromPassword("value3"), null);
 
-        Set<String> aliases = store.getAliases(mountPath + "/app1", true, 1);
+        Set<String> aliases = store.getAliases("#app1", true, 1);
 
-        assertTrue(aliases.contains(mountPath + "/app1.key1"),
+        assertTrue(aliases.contains("#app1?key1"),
             String.format("Should contain top-level key in %s", version));
-        assertTrue(aliases.contains(mountPath + "/app1/subapp1.key2"),
+        assertTrue(aliases.contains("#app1/subapp1?key2"),
             String.format("Should contain depth-1 key in %s", version));
-        assertFalse(aliases.contains(mountPath + "/app1/subapp1/deep.key3"),
+        assertFalse(aliases.contains("#app1/subapp1/deep?key3"),
             String.format("Should not include depth-2 keys in %s", version));
     }
 
@@ -347,20 +355,18 @@ public class HashicorpVaultCredentialStoreKvVersionTestCase {
         HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer, version, mountPath);
 
         // Create multiple subpaths at same level
-        store.store(mountPath + "/app1.key1", createCredentialFromPassword("value1"), null);
-        store.store(mountPath + "/app1/subapp1.key2", createCredentialFromPassword("value2"), null);
-        store.store(mountPath + "/app1/subapp2.key3", createCredentialFromPassword("value3"), null);
-        store.store(mountPath + "/app1/subapp3.key4", createCredentialFromPassword("value4"), null);
+        store.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        store.store("#app1/subapp1?key2", createCredentialFromPassword("value2"), null);
+        store.store("#app1/subapp2?key3", createCredentialFromPassword("value3"), null);
+        store.store("#app1/subapp3?key4", createCredentialFromPassword("value4"), null);
 
-        Set<String> aliases = store.getAliases(mountPath + "/app1", true, 1);
+        Set<String> aliases = store.getAliases("#app1", true, 1);
 
         assertEquals(4, aliases.size(),
             String.format("Should find all 4 aliases in %s", version));
-        assertTrue(aliases.contains(mountPath + "/app1.key1"));
-        assertTrue(aliases.contains(mountPath + "/app1/subapp1.key2"));
-        assertTrue(aliases.contains(mountPath + "/app1/subapp2.key3"));
-        assertTrue(aliases.contains(mountPath + "/app1/subapp3.key4"));
+        assertTrue(aliases.contains("#app1?key1"));
+        assertTrue(aliases.contains("#app1/subapp1?key2"));
+        assertTrue(aliases.contains("#app1/subapp2?key3"));
+        assertTrue(aliases.contains("#app1/subapp3?key4"));
     }
 }
-
-// Made with Bob

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreKvVersionTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreKvVersionTestCase.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.spec.InvalidKeySpecException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.vault.VaultContainer;
+import org.wildfly.security.auth.server.IdentityCredentials;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.store.CredentialStore;
+import org.wildfly.security.hashicorp.vault.KvVersionTestHelper.KvVersion;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+/**
+ * Parameterized test suite for {@link HashicorpVaultCredentialStore} covering both KV v1 and KV v2 engines.
+ *
+ * <p>This test class uses JUnit 5's {@code @ParameterizedTest} to run the same test logic
+ * against different Vault configurations:
+ * <ul>
+ *   <li>KV v1 only</li>
+ *   <li>KV v2 only (default)</li>
+ *   <li>Mixed environment (both v1 and v2 at different mounts)</li>
+ * </ul>
+ *
+ * <p><strong>Test Coverage:</strong>
+ * <ul>
+ *   <li>Credential store operations (store, retrieve, remove)</li>
+ *   <li>Alias listing (recursive and non-recursive)</li>
+ *   <li>Multi-key credential handling</li>
+ *   <li>Path-based operations</li>
+ * </ul>
+ */
+public class HashicorpVaultCredentialStoreKvVersionTestCase {
+
+    private VaultContainer<?> vaultContainer;
+
+    @AfterEach
+    public void cleanup() {
+        if (vaultContainer != null) {
+            vaultContainer.stop();
+        }
+    }
+
+    /**
+     * Provides test configurations for parameterized tests.
+     */
+    static Stream<Arguments> kvVersionConfigurations() {
+        return Stream.of(
+            // KV v1 only
+            Arguments.of(new VaultContainerKvV1<>("hashicorp/vault:1.13"), "secret", KvVersion.V1),
+
+            // KV v2 only (using standard VaultContainer which defaults to v2)
+            Arguments.of(new VaultContainer<>("hashicorp/vault:1.13")
+                .withVaultToken("myroot")
+                .withInitCommand(
+                    "secrets enable transit",
+                    "write -f transit/keys/my-key",
+                    "kv put secret/testing1 top_secret=password123",
+                    "kv put secret/testing2 dbuser=secretpass jmsuser=jmspass"
+                ), "secret", KvVersion.V2),
+
+            // Mixed: KV v1 at secret-v1/
+            Arguments.of(new VaultContainerKvMixed<>("hashicorp/vault:1.13"), "secret-v1", KvVersion.V1),
+
+            // Mixed: KV v2 at secret/
+            Arguments.of(new VaultContainerKvMixed<>("hashicorp/vault:1.13"), "secret", KvVersion.V2)
+        );
+    }
+
+    private HashicorpVaultCredentialStore createCredentialStore(VaultContainer<?> container) throws Exception {
+        HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("host-address", container.getHttpHostAddress());
+        attributes.put("namespace", "admin");
+        store.initialize(attributes,
+            new CredentialStore.CredentialSourceProtectionParameter(
+                IdentityCredentials.NONE.withCredential(createCredentialFromPassword("myroot"))),
+            new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
+        return store;
+    }
+
+    private PasswordCredential createCredentialFromPassword(String password)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR,
+            WildFlyElytronPasswordProvider.getInstance());
+        return new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec(password.toCharArray())));
+    }
+
+    private CredentialStore.CredentialSourceProtectionParameter createProtectionParameter(String token)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        return new CredentialStore.CredentialSourceProtectionParameter(
+            IdentityCredentials.NONE.withCredential(createCredentialFromPassword(token)));
+    }
+
+    // =====================================================================
+    // Basic Credential Store Operations
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] Retrieve credential from {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testCredentialStoreRetrieve(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+        PasswordCredential credential = store.retrieve(
+            mountPath + "/testing1.top_secret",
+            PasswordCredential.class,
+            ClearPassword.ALGORITHM_CLEAR,
+            null,
+            null);
+
+        assertNotNull(credential, String.format("Should retrieve credential from %s", version));
+        assertEquals("password123", String.valueOf(credential.getPassword(ClearPassword.class).getPassword()),
+            String.format("Should retrieve correct password from %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Store credential to {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testCredentialStorePut(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+
+        // Store a new credential
+        store.store(mountPath + "/testing1.test_secret", createCredentialFromPassword("testPassword"), null);
+
+        // Retrieve and verify
+        PasswordCredential credential = store.retrieve(
+            mountPath + "/testing1.test_secret",
+            PasswordCredential.class,
+            ClearPassword.ALGORITHM_CLEAR,
+            null,
+            createProtectionParameter("myroot"));
+
+        assertNotNull(credential, String.format("Should store credential in %s", version));
+        assertEquals("testPassword", String.valueOf(credential.getPassword(ClearPassword.class).getPassword()),
+            String.format("Should retrieve stored password from %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Store multiple credentials maintains existing keys at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testPutMaintainsExistingKeys(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+
+        // Store two credentials at the same path
+        store.store(mountPath + "/myapp.mp", createCredentialFromPassword("password1"), null);
+        store.store(mountPath + "/myapp.mp2", createCredentialFromPassword("password2"), null);
+
+        // Verify both exist
+        PasswordCredential credential1 = store.retrieve(
+            mountPath + "/myapp.mp",
+            PasswordCredential.class,
+            ClearPassword.ALGORITHM_CLEAR,
+            null,
+            createProtectionParameter("myroot"));
+        assertNotNull(credential1, String.format("First credential should exist in %s", version));
+
+        PasswordCredential credential2 = store.retrieve(
+            mountPath + "/myapp.mp2",
+            PasswordCredential.class,
+            ClearPassword.ALGORITHM_CLEAR,
+            null,
+            createProtectionParameter("myroot"));
+        assertNotNull(credential2, String.format("Second credential should exist in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Remove credential keeps other keys at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testRemoveKeepsOtherKeys(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+
+        // Store two credentials
+        store.store(mountPath + "/myapp.mp", createCredentialFromPassword("password1"), null);
+        store.store(mountPath + "/myapp.mp2", createCredentialFromPassword("password2"), null);
+
+        // Remove one
+        store.remove(mountPath + "/myapp.mp2", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null);
+
+        // Verify first still exists
+        PasswordCredential remaining = store.retrieve(
+            mountPath + "/myapp.mp",
+            PasswordCredential.class,
+            ClearPassword.ALGORITHM_CLEAR,
+            null,
+            createProtectionParameter("myroot"));
+        assertNotNull(remaining, String.format("Remaining credential should exist in %s", version));
+        assertEquals("password1", String.valueOf(remaining.getPassword(ClearPassword.class).getPassword()));
+
+        // Verify second is gone
+        PasswordCredential removed = store.retrieve(
+            mountPath + "/myapp.mp2",
+            PasswordCredential.class,
+            ClearPassword.ALGORITHM_CLEAR,
+            null,
+            createProtectionParameter("myroot"));
+        assertNull(removed, String.format("Removed credential should not exist in %s", version));
+    }
+
+    // =====================================================================
+    // Alias Listing Operations
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] Get aliases with path at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetAliasesWithPath(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+
+        Set<String> aliases = store.getAliases(mountPath + "/testing1");
+        assertNotNull(aliases, String.format("Should return aliases in %s", version));
+        assertFalse(aliases.isEmpty(), String.format("Should have aliases in %s", version));
+        assertTrue(aliases.contains(mountPath + "/testing1.top_secret"),
+            String.format("Should contain expected alias in %s", version));
+
+        // Verify it doesn't contain aliases from other paths
+        assertFalse(aliases.contains(mountPath + "/testing2.dbuser"),
+            String.format("Should not contain aliases from other paths in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Get aliases for multiple paths at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetAliasesMultiplePaths(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+
+        // Get aliases from testing1
+        Set<String> aliases1 = store.getAliases(mountPath + "/testing1");
+        assertTrue(aliases1.contains(mountPath + "/testing1.top_secret"));
+        assertFalse(aliases1.contains(mountPath + "/testing2.dbuser"));
+
+        // Get aliases from testing2
+        Set<String> aliases2 = store.getAliases(mountPath + "/testing2");
+        assertTrue(aliases2.contains(mountPath + "/testing2.dbuser"));
+        assertTrue(aliases2.contains(mountPath + "/testing2.jmsuser"));
+        assertFalse(aliases2.contains(mountPath + "/testing1.top_secret"));
+    }
+
+    @ParameterizedTest(name = "[{2}] Get aliases non-recursive at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetAliasesNonRecursive(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+
+        Set<String> aliases1 = store.getAliases(mountPath + "/testing1");
+        Set<String> aliases2 = store.getAliases(mountPath + "/testing1", false, 0);
+
+        assertEquals(aliases1, aliases2,
+            String.format("Non-recursive should match default behavior in %s", version));
+        assertTrue(aliases2.contains(mountPath + "/testing1.top_secret"));
+    }
+
+    @ParameterizedTest(name = "[{2}] Get aliases recursive depth 0 at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetAliasesRecursiveDepth0(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+
+        // Create nested structure
+        store.store(mountPath + "/app1.key1", createCredentialFromPassword("value1"), null);
+        store.store(mountPath + "/app1.key2", createCredentialFromPassword("value2"), null);
+        store.store(mountPath + "/app1/subapp.key3", createCredentialFromPassword("value3"), null);
+
+        Set<String> aliases = store.getAliases(mountPath + "/app1", true, 0);
+
+        assertTrue(aliases.contains(mountPath + "/app1.key1"),
+            String.format("Should contain top-level key1 in %s", version));
+        assertTrue(aliases.contains(mountPath + "/app1.key2"),
+            String.format("Should contain top-level key2 in %s", version));
+        assertFalse(aliases.contains(mountPath + "/app1/subapp.key3"),
+            String.format("Should not include nested keys at depth 0 in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Get aliases recursive depth 1 at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetAliasesRecursiveDepth1(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+
+        // Create nested structure
+        store.store(mountPath + "/app1.key1", createCredentialFromPassword("value1"), null);
+        store.store(mountPath + "/app1/subapp1.key2", createCredentialFromPassword("value2"), null);
+        store.store(mountPath + "/app1/subapp1/deep.key3", createCredentialFromPassword("value3"), null);
+
+        Set<String> aliases = store.getAliases(mountPath + "/app1", true, 1);
+
+        assertTrue(aliases.contains(mountPath + "/app1.key1"),
+            String.format("Should contain top-level key in %s", version));
+        assertTrue(aliases.contains(mountPath + "/app1/subapp1.key2"),
+            String.format("Should contain depth-1 key in %s", version));
+        assertFalse(aliases.contains(mountPath + "/app1/subapp1/deep.key3"),
+            String.format("Should not include depth-2 keys in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Get aliases recursive multiple subpaths at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetAliasesRecursiveMultipleSubpaths(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        HashicorpVaultCredentialStore store = createCredentialStore(vaultContainer);
+
+        // Create multiple subpaths at same level
+        store.store(mountPath + "/app1.key1", createCredentialFromPassword("value1"), null);
+        store.store(mountPath + "/app1/subapp1.key2", createCredentialFromPassword("value2"), null);
+        store.store(mountPath + "/app1/subapp2.key3", createCredentialFromPassword("value3"), null);
+        store.store(mountPath + "/app1/subapp3.key4", createCredentialFromPassword("value4"), null);
+
+        Set<String> aliases = store.getAliases(mountPath + "/app1", true, 1);
+
+        assertEquals(4, aliases.size(),
+            String.format("Should find all 4 aliases in %s", version));
+        assertTrue(aliases.contains(mountPath + "/app1.key1"));
+        assertTrue(aliases.contains(mountPath + "/app1/subapp1.key2"));
+        assertTrue(aliases.contains(mountPath + "/app1/subapp2.key3"));
+        assertTrue(aliases.contains(mountPath + "/app1/subapp3.key4"));
+    }
+}
+
+// Made with Bob

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreProviderTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreProviderTestCase.java
@@ -8,7 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.security.Security;
+
 import org.junit.jupiter.api.Test;
+import org.wildfly.security.credential.store.CredentialStore;
 
 /**
  * Unit tests for {@link HashicorpVaultCredentialStoreProvider}.
@@ -45,5 +48,22 @@ public class HashicorpVaultCredentialStoreProviderTestCase {
     public void testProviderRegistersCredentialStoreService() {
         HashicorpVaultCredentialStoreProvider provider = HashicorpVaultCredentialStoreProvider.getInstance();
         assertNotNull(provider.getService("CredentialStore", "HashicorpVaultCredentialStore"));
+    }
+
+    /**
+     * Verify that the package-private {@code HashicorpVaultCredentialStore} class can be instantiated
+     * via the Security Provider framework using reflection.
+     * Test passes when {@code CredentialStore.getInstance()} successfully returns a non-null instance.
+     */
+    @Test
+    public void testCredentialStoreCanBeInstantiatedViaSecurityProvider() throws Exception {
+        HashicorpVaultCredentialStoreProvider provider = HashicorpVaultCredentialStoreProvider.getInstance();
+        Security.addProvider(provider);
+        try {
+            CredentialStore credentialStore = CredentialStore.getInstance("HashicorpVaultCredentialStore", provider);
+            assertNotNull(credentialStore);
+        } finally {
+            Security.removeProvider(provider.getName());
+        }
     }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreProviderTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreProviderTestCase.java
@@ -4,11 +4,11 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link HashicorpVaultCredentialStoreProvider}.

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
@@ -124,20 +124,21 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.initialize(attributes, new CredentialStore.CredentialSourceProtectionParameter(
                         IdentityCredentials.NONE.withCredential(createCredentialFromPassword("myroot"))),
                 new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
-        Set<String> aliases = cs.getAliases("secret/testing1");
+        Set<String> aliases = cs.getAliases("@secret#testing1");
         assertNotNull(aliases);
         assertFalse(aliases.isEmpty());
         assertTrue(aliases.contains("#testing1?top_secret"));
         assertFalse(aliases.contains("#testing2?dbuser"));
         assertFalse(aliases.contains("#testing2?jmsuser"));
 
-        aliases = cs.getAliases("secret/testing2");
+        aliases = cs.getAliases("@secret#testing2");
         assertNotNull(aliases);
         assertFalse(aliases.isEmpty());
         assertTrue(aliases.contains("#testing2?dbuser"));
         assertTrue(aliases.contains("#testing2?jmsuser"));
         assertFalse(aliases.contains("#testing1?top_secret"));
     }
+
 
     /**
      * The call must throw a {@link CredentialStoreException} when null path is provided
@@ -177,8 +178,8 @@ public class HashicorpVaultCredentialStoreTestCase {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
 
-        Set<String> aliases1 = cs.getAliases("secret/testing1");
-        Set<String> aliases2 = cs.getAliases("secret/testing1", false, 0);
+        Set<String> aliases1 = cs.getAliases("@secret#testing1");
+        Set<String> aliases2 = cs.getAliases("@secret#testing1", false, 0);
 
         assertEquals(aliases1, aliases2);
         assertTrue(aliases2.contains("#testing1?top_secret"));
@@ -196,7 +197,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.store("#app1?key2", createCredentialFromPassword("value2"), null);
         cs.store("#app1/subapp?key3", createCredentialFromPassword("value3"), null);
 
-        Set<String> aliases = cs.getAliases("secret/app1", true, 0);
+        Set<String> aliases = cs.getAliases("@secret#app1", true, 0);
 
         assertTrue(aliases.contains("#app1?key1"));
         assertTrue(aliases.contains("#app1?key2"));
@@ -217,7 +218,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.store("#app1/subapp1?key3", createCredentialFromPassword("value3"), null);
         cs.store("#app1/subapp2?key4", createCredentialFromPassword("value4"), null);
         cs.store("#app1/subapp1/deep?key5", createCredentialFromPassword("value5"), null);
-        Set<String> aliases = cs.getAliases("secret/app1", true, 1);
+        Set<String> aliases = cs.getAliases("@secret#app1", true, 1);
 
         assertTrue(aliases.contains("#app1?key1"));
         assertTrue(aliases.contains("#app1?key2"));
@@ -241,7 +242,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.store("#app1/subapp1/deep?key3", createCredentialFromPassword("value3"), null);
         cs.store("#app1/subapp1/deep/deeper?key4", createCredentialFromPassword("value4"), null);
 
-        Set<String> aliases = cs.getAliases("secret/app1", true, 2);
+        Set<String> aliases = cs.getAliases("@secret#app1", true, 2);
         assertTrue(aliases.contains("#app1?key1"));
         assertTrue(aliases.contains("#app1/subapp1?key2"));
         assertTrue(aliases.contains("#app1/subapp1/deep?key3"));
@@ -262,7 +263,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.store("#app1/subapp2?key3", createCredentialFromPassword("value3"), null);
         cs.store("#app1/subapp3?key4", createCredentialFromPassword("value4"), null);
 
-        Set<String> aliases = cs.getAliases("secret/app1", true, 1);
+        Set<String> aliases = cs.getAliases("@secret#app1", true, 1);
 
         assertTrue(aliases.contains("#app1?key1"));
         assertTrue(aliases.contains("#app1/subapp1?key2"));
@@ -282,7 +283,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.store("#app1?key1", createCredentialFromPassword("value1"), null);
         cs.store("#app1/subapp1/deep?key2", createCredentialFromPassword("value2"), null);
 
-        Set<String> aliases = cs.getAliases("secret/app1", true, 2);
+        Set<String> aliases = cs.getAliases("@secret#app1", true, 2);
 
         assertTrue(aliases.contains("#app1?key1"));
         assertTrue(aliases.contains("#app1/subapp1/deep?key2"));
@@ -303,7 +304,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.store("#app1/subapp2?key5", createCredentialFromPassword("value5"), null);
         cs.store("#app1/subapp2?key6", createCredentialFromPassword("value6"), null);
 
-        Set<String> aliases = cs.getAliases("secret/app1", true, 1, 3);
+        Set<String> aliases = cs.getAliases("@secret#app1", true, 1, 3);
         assertTrue(aliases.contains("#app1?key1"));
         assertTrue(aliases.contains("#app1?key2"));
         assertEquals(3, aliases.size());
@@ -322,7 +323,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.store("#app1/subapp1/deep?key3", createCredentialFromPassword("value3"), null);
         cs.store("#app1/subapp2?key4", createCredentialFromPassword("value4"), null);
 
-        Set<String> aliases = cs.getAliases("secret/app1", true, 2, 2);
+        Set<String> aliases = cs.getAliases("@secret#app1", true, 2, 2);
 
         assertTrue(aliases.contains("#app1?key1"));
         assertEquals(2, aliases.size());
@@ -339,7 +340,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.store("#app1?key1", createCredentialFromPassword("value1"), null);
         cs.store("#app1?key2", createCredentialFromPassword("value2"), null);
         cs.store("#app1/subapp1?key3", createCredentialFromPassword("value3"), null);
-        Set<String> aliases = cs.getAliases("secret/app1", false, 10, 1);
+        Set<String> aliases = cs.getAliases("@secret#app1", false, 10, 1);
 
         assertEquals(1, aliases.size());
         assertTrue(aliases.contains("#app1?key1") || aliases.contains("#app1?key2"));
@@ -746,5 +747,115 @@ public class HashicorpVaultCredentialStoreTestCase {
         HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
         assertThrows(CredentialStoreException.class,
                 () -> store.getAliases("secret/"));
+    }
+
+    // =====================================================================
+    // Path format tests for getAliases() - PR #71 implementation
+    // =====================================================================
+
+    /**
+     * Test root path listing with legacy format (mount/)
+     * When supportLegacyAliasFormat=true, "secret/" should list root of secret mount
+     */
+    @Test
+    public void testGetAliasesRootPathLegacyFormat() throws Exception {
+        vaultTestContainer = startVaultTestContainer();
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("host-address", vaultTestContainer.getHttpHostAddress());
+        attributes.put("namespace", "admin");
+        attributes.put("support-legacy-alias-format", "true");
+
+        HashicorpVaultCredentialStore cs = new HashicorpVaultCredentialStore();
+        cs.initialize(attributes,
+            new CredentialStore.CredentialSourceProtectionParameter(
+                IdentityCredentials.NONE.withCredential(createCredentialFromPassword("myroot"))),
+            new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
+
+        Set<String> aliases = cs.getAliases("secret/", true, 1);
+        assertNotNull(aliases);
+        assertTrue(aliases.contains("#testing1?top_secret"), "Should contain #testing1?top_secret");
+        assertTrue(aliases.contains("#testing2?dbuser"), "Should contain #testing2?dbuser. Got: " + aliases);
+        assertTrue(aliases.contains("#testing2?jmsuser"), "Should contain #testing2?jmsuser. Got: " + aliases);
+    }
+
+    /**
+     * Test root path listing with new format (@mount#)
+     * "@secret#" should list root of secret mount
+     */
+    @Test
+    public void testGetAliasesRootPathNewFormat() throws Exception {
+        vaultTestContainer = startVaultTestContainer();
+        HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
+
+        Set<String> aliases = cs.getAliases("@secret#", true, 1);
+        assertNotNull(aliases);
+        assertTrue(aliases.contains("#testing1?top_secret"), "Should contain #testing1?top_secret");
+        assertTrue(aliases.contains("#testing2?dbuser"), "Should contain #testing2?dbuser");
+        assertTrue(aliases.contains("#testing2?jmsuser"), "Should contain #testing2?jmsuser");
+    }
+
+    /**
+     * Test root path with default mount - all these formats should be equivalent
+     * "#", "#/", "/", and "" should all list root of default mount
+     */
+    @Test
+    public void testGetAliasesRootPathDefaultMount() throws Exception {
+        vaultTestContainer = startVaultTestContainer();
+        HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
+
+        // All these should be equivalent and list root of default mount (secret)
+        Set<String> aliases1 = cs.getAliases("#", true, 1);
+        Set<String> aliases2 = cs.getAliases("#/", true, 1);
+        Set<String> aliases3 = cs.getAliases("/", true, 1);
+
+        // Verify all return the same results
+        assertEquals(aliases1, aliases2, "#  and #/ should return same results");
+        assertEquals(aliases1, aliases3, "# and / should return same results");
+
+        // Verify they contain expected aliases
+        assertTrue(aliases1.contains("#testing1?top_secret"));
+        assertTrue(aliases1.contains("#testing2?dbuser"));
+    }
+
+    /**
+     * Test legacy format rejected when supportLegacyAliasFormat=false
+     * "secret/testing1" should throw exception when legacy format is disabled
+     */
+    @Test
+    public void testGetAliasesLegacyFormatRejected() throws Exception {
+        vaultTestContainer = startVaultTestContainer();
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("host-address", vaultTestContainer.getHttpHostAddress());
+        attributes.put("support-legacy-alias-format", "false");
+
+        HashicorpVaultCredentialStore cs = new HashicorpVaultCredentialStore();
+        cs.initialize(attributes,
+            new CredentialStore.CredentialSourceProtectionParameter(
+                IdentityCredentials.NONE.withCredential(createCredentialFromPassword("myroot"))),
+            new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
+
+        CredentialStoreException ex = assertThrows(
+            CredentialStoreException.class,
+            () -> cs.getAliases("secret/testing1"),
+            "Should reject legacy format when supportLegacyAliasFormat=false"
+        );
+        assertTrue(ex.getMessage().contains("Legacy path format"),
+            "Error message should mention legacy path format, got: " + ex.getMessage());
+    }
+
+    /**
+     * Test path equivalence: #path and path are equivalent
+     * Both "#testing1" and "testing1" should return the same results
+     */
+    @Test
+    public void testGetAliasesPathEquivalence() throws Exception {
+        vaultTestContainer = startVaultTestContainer();
+        HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
+
+        Set<String> aliases1 = cs.getAliases("#testing1");
+        Set<String> aliases2 = cs.getAliases("testing1");
+
+        assertEquals(aliases1, aliases2, "#testing1 and testing1 should return same results");
+        assertTrue(aliases1.contains("#testing1?top_secret"));
     }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
@@ -818,8 +818,8 @@ public class HashicorpVaultCredentialStoreTestCase {
     }
 
     /**
-     * Test legacy format rejected when supportLegacyAliasFormat=false
-     * "secret/testing1" should throw exception when legacy format is disabled
+     * Test that paths with slashes are treated as new format secret paths when legacy format is disabled.
+     * "secret/testing1" should be interpreted as a secret path (not mount/secret) since # is optional in new format.
      */
     @Test
     public void testGetAliasesLegacyFormatRejected() throws Exception {
@@ -834,13 +834,10 @@ public class HashicorpVaultCredentialStoreTestCase {
                 IdentityCredentials.NONE.withCredential(createCredentialFromPassword("myroot"))),
             new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
 
-        CredentialStoreException ex = assertThrows(
-            CredentialStoreException.class,
-            () -> cs.getAliases("secret/testing1"),
-            "Should reject legacy format when supportLegacyAliasFormat=false"
-        );
-        assertTrue(ex.getMessage().contains("Legacy path format"),
-            "Error message should mention legacy path format, got: " + ex.getMessage());
+        // When legacy format is disabled, "secret/testing1" is treated as a new format secret path
+        // (since # is optional). This should NOT throw an exception.
+        Set<String> aliases = cs.getAliases("secret/testing1");
+        assertNotNull(aliases, "Should return aliases for new format secret path");
     }
 
     /**
@@ -857,5 +854,52 @@ public class HashicorpVaultCredentialStoreTestCase {
 
         assertEquals(aliases1, aliases2, "#testing1 and testing1 should return same results");
         assertTrue(aliases1.contains("#testing1?top_secret"));
+    }
+
+    /**
+     * Test engine= prefix with explicit mount in getAliases()
+     * "engine=KVv2@secret#testing1" should work correctly
+     */
+    @Test
+    public void testGetAliasesWithEngineAndMount() throws Exception {
+        vaultTestContainer = startVaultTestContainer();
+        HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
+
+        Set<String> aliases = cs.getAliases("engine=KVv2@secret#testing1");
+        assertNotNull(aliases);
+        assertTrue(aliases.contains("#testing1?top_secret"),
+            "Should contain #testing1?top_secret when using engine=KVv2@secret#testing1");
+    }
+
+    /**
+     * Test engine= prefix with default mount in getAliases()
+     * "engine=KVv2#testing1" should work correctly
+     */
+    @Test
+    public void testGetAliasesWithEngineDefaultMount() throws Exception {
+        vaultTestContainer = startVaultTestContainer();
+        HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
+
+        Set<String> aliases = cs.getAliases("engine=KVv2#testing1");
+        assertNotNull(aliases);
+        assertTrue(aliases.contains("#testing1?top_secret"),
+            "Should contain #testing1?top_secret when using engine=KVv2#testing1");
+    }
+
+    /**
+     * Test engine= prefix for root path listing
+     * "engine=KVv2@secret#" should list root of secret mount
+     */
+    @Test
+    public void testGetAliasesWithEngineRootPath() throws Exception {
+        vaultTestContainer = startVaultTestContainer();
+        HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
+
+        Set<String> aliases = cs.getAliases("engine=KVv2@secret#", true, 1);
+        assertNotNull(aliases);
+        assertTrue(aliases.contains("#testing1?top_secret"),
+            "Should contain #testing1?top_secret");
+        assertTrue(aliases.contains("#testing2?dbuser"),
+            "Should contain #testing2?dbuser");
     }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
@@ -58,7 +58,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         attributes.put("namespace", "admin");
         cs.initialize(attributes, new CredentialStore.CredentialSourceProtectionParameter(
                 IdentityCredentials.NONE.withCredential(createCredentialFromPassword("myroot"))), new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
-        PasswordCredential credential = cs.retrieve("secret/testing1.top_secret", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, null);
+        PasswordCredential credential = cs.retrieve("#testing1?top_secret", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, null);
         assertEquals("password123", String.valueOf(credential.getPassword(ClearPassword.class).getPassword()));
     }
 
@@ -73,9 +73,9 @@ public class HashicorpVaultCredentialStoreTestCase {
         attributes.put("namespace", "admin");
         hashicorpVaultCredentialStore.initialize(attributes, new CredentialStore.CredentialSourceProtectionParameter(
                 IdentityCredentials.NONE.withCredential(createCredentialFromPassword("myroot"))), new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
-        hashicorpVaultCredentialStore.store("secret/testing1.test_secret", createCredentialFromPassword("testPassword"), null);
+        hashicorpVaultCredentialStore.store("#testing1?test_secret", createCredentialFromPassword("testPassword"), null);
         PasswordCredential credential = hashicorpVaultCredentialStore
-                .retrieve("secret/testing1.test_secret", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null,
+                .retrieve("#testing1?test_secret", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null,
                         new CredentialStore.CredentialSourceProtectionParameter(
                 IdentityCredentials.NONE.withCredential(createCredentialFromPassword("myroot"))));
         assertEquals("testPassword", String.valueOf(credential.getPassword(ClearPassword.class).getPassword()));
@@ -85,12 +85,12 @@ public class HashicorpVaultCredentialStoreTestCase {
     public void testPutMaintainsExistingKeys() throws Exception {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore store = createHashicorpVaultCredentialStore();
-        store.store("secret/myapp.mp", createCredentialFromPassword("password1"), null);
-        store.store("secret/myapp.mp2", createCredentialFromPassword("password2"), null);
-        PasswordCredential credential1 = store.retrieve("secret/myapp.mp", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR,
+        store.store("#myapp?mp", createCredentialFromPassword("password1"), null);
+        store.store("#myapp?mp2", createCredentialFromPassword("password2"), null);
+        PasswordCredential credential1 = store.retrieve("#myapp?mp", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR,
                 null, createProtectionParameter("myroot"));
         assertNotNull(credential1);
-        PasswordCredential credential2 = store.retrieve("secret/myapp.mp2", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR,
+        PasswordCredential credential2 = store.retrieve("#myapp?mp2", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR,
                 null, createProtectionParameter("myroot"));
         assertNotNull(credential2);
     }
@@ -99,14 +99,14 @@ public class HashicorpVaultCredentialStoreTestCase {
     public void testRemoveKeepsOtherKeys() throws Exception {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore store = createHashicorpVaultCredentialStore();
-        store.store("secret/myapp.mp", createCredentialFromPassword("password1"), null);
-        store.store("secret/myapp.mp2", createCredentialFromPassword("password2"), null);
-        store.remove("secret/myapp.mp2", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null);
-        PasswordCredential remaining = store.retrieve("secret/myapp.mp", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR,
+        store.store("#myapp?mp", createCredentialFromPassword("password1"), null);
+        store.store("#myapp?mp2", createCredentialFromPassword("password2"), null);
+        store.remove("#myapp?mp2", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null);
+        PasswordCredential remaining = store.retrieve("#myapp?mp", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR,
                 null, createProtectionParameter("myroot"));
         assertNotNull(remaining);
         assertEquals("password1", String.valueOf(remaining.getPassword(ClearPassword.class).getPassword()));
-        PasswordCredential removed = store.retrieve("secret/myapp.mp2", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR,
+        PasswordCredential removed = store.retrieve("#myapp?mp2", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR,
                 null, createProtectionParameter("myroot"));
         assertNull(removed);
     }
@@ -127,16 +127,16 @@ public class HashicorpVaultCredentialStoreTestCase {
         Set<String> aliases = cs.getAliases("secret/testing1");
         assertNotNull(aliases);
         assertFalse(aliases.isEmpty());
-        assertTrue(aliases.contains("secret/testing1.top_secret"));
-        assertFalse(aliases.contains("secret/testing2.dbuser"));
-        assertFalse(aliases.contains("secret/testing2.jmsuser"));
+        assertTrue(aliases.contains("#testing1?top_secret"));
+        assertFalse(aliases.contains("#testing2?dbuser"));
+        assertFalse(aliases.contains("#testing2?jmsuser"));
 
         aliases = cs.getAliases("secret/testing2");
         assertNotNull(aliases);
         assertFalse(aliases.isEmpty());
-        assertTrue(aliases.contains("secret/testing2.dbuser"));
-        assertTrue(aliases.contains("secret/testing2.jmsuser"));
-        assertFalse(aliases.contains("secret/testing1.top_secret"));
+        assertTrue(aliases.contains("#testing2?dbuser"));
+        assertTrue(aliases.contains("#testing2?jmsuser"));
+        assertFalse(aliases.contains("#testing1?top_secret"));
     }
 
     /**
@@ -181,7 +181,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         Set<String> aliases2 = cs.getAliases("secret/testing1", false, 0);
 
         assertEquals(aliases1, aliases2);
-        assertTrue(aliases2.contains("secret/testing1.top_secret"));
+        assertTrue(aliases2.contains("#testing1?top_secret"));
     }
 
     /**
@@ -192,16 +192,16 @@ public class HashicorpVaultCredentialStoreTestCase {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
 
-        cs.store("secret/app1.key1", createCredentialFromPassword("value1"), null);
-        cs.store("secret/app1.key2", createCredentialFromPassword("value2"), null);
-        cs.store("secret/app1/subapp.key3", createCredentialFromPassword("value3"), null);
+        cs.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        cs.store("#app1?key2", createCredentialFromPassword("value2"), null);
+        cs.store("#app1/subapp?key3", createCredentialFromPassword("value3"), null);
 
         Set<String> aliases = cs.getAliases("secret/app1", true, 0);
 
-        assertTrue(aliases.contains("secret/app1.key1"));
-        assertTrue(aliases.contains("secret/app1.key2"));
+        assertTrue(aliases.contains("#app1?key1"));
+        assertTrue(aliases.contains("#app1?key2"));
         // Should NOT include any subpath keys when depth is 0
-        assertFalse(aliases.contains("secret/app1/subapp.key3"));
+        assertFalse(aliases.contains("#app1/subapp?key3"));
     }
 
     /**
@@ -212,19 +212,19 @@ public class HashicorpVaultCredentialStoreTestCase {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
 
-        cs.store("secret/app1.key1", createCredentialFromPassword("value1"), null);
-        cs.store("secret/app1.key2", createCredentialFromPassword("value2"), null);
-        cs.store("secret/app1/subapp1.key3", createCredentialFromPassword("value3"), null);
-        cs.store("secret/app1/subapp2.key4", createCredentialFromPassword("value4"), null);
-        cs.store("secret/app1/subapp1/deep.key5", createCredentialFromPassword("value5"), null);
+        cs.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        cs.store("#app1?key2", createCredentialFromPassword("value2"), null);
+        cs.store("#app1/subapp1?key3", createCredentialFromPassword("value3"), null);
+        cs.store("#app1/subapp2?key4", createCredentialFromPassword("value4"), null);
+        cs.store("#app1/subapp1/deep?key5", createCredentialFromPassword("value5"), null);
         Set<String> aliases = cs.getAliases("secret/app1", true, 1);
 
-        assertTrue(aliases.contains("secret/app1.key1"));
-        assertTrue(aliases.contains("secret/app1.key2"));
+        assertTrue(aliases.contains("#app1?key1"));
+        assertTrue(aliases.contains("#app1?key2"));
 
-        assertTrue(aliases.contains("secret/app1/subapp1.key3"));
-        assertTrue(aliases.contains("secret/app1/subapp2.key4"));
-        assertFalse(aliases.contains("secret/app1/subapp1/deep.key5"));
+        assertTrue(aliases.contains("#app1/subapp1?key3"));
+        assertTrue(aliases.contains("#app1/subapp2?key4"));
+        assertFalse(aliases.contains("#app1/subapp1/deep?key5"));
 
     }
 
@@ -236,17 +236,17 @@ public class HashicorpVaultCredentialStoreTestCase {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
 
-        cs.store("secret/app1.key1", createCredentialFromPassword("value1"), null);
-        cs.store("secret/app1/subapp1.key2", createCredentialFromPassword("value2"), null);
-        cs.store("secret/app1/subapp1/deep.key3", createCredentialFromPassword("value3"), null);
-        cs.store("secret/app1/subapp1/deep/deeper.key4", createCredentialFromPassword("value4"), null);
+        cs.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        cs.store("#app1/subapp1?key2", createCredentialFromPassword("value2"), null);
+        cs.store("#app1/subapp1/deep?key3", createCredentialFromPassword("value3"), null);
+        cs.store("#app1/subapp1/deep/deeper?key4", createCredentialFromPassword("value4"), null);
 
         Set<String> aliases = cs.getAliases("secret/app1", true, 2);
-        assertTrue(aliases.contains("secret/app1.key1"));
-        assertTrue(aliases.contains("secret/app1/subapp1.key2"));
-        assertTrue(aliases.contains("secret/app1/subapp1/deep.key3"));
+        assertTrue(aliases.contains("#app1?key1"));
+        assertTrue(aliases.contains("#app1/subapp1?key2"));
+        assertTrue(aliases.contains("#app1/subapp1/deep?key3"));
         // Should NOT include keys deeper than depth 2
-        assertFalse(aliases.contains("secret/app1/subapp1/deep/deeper.key4"));
+        assertFalse(aliases.contains("#app1/subapp1/deep/deeper?key4"));
     }
 
     /**
@@ -257,17 +257,17 @@ public class HashicorpVaultCredentialStoreTestCase {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
 
-        cs.store("secret/app1.key1", createCredentialFromPassword("value1"), null);
-        cs.store("secret/app1/subapp1.key2", createCredentialFromPassword("value2"), null);
-        cs.store("secret/app1/subapp2.key3", createCredentialFromPassword("value3"), null);
-        cs.store("secret/app1/subapp3.key4", createCredentialFromPassword("value4"), null);
+        cs.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        cs.store("#app1/subapp1?key2", createCredentialFromPassword("value2"), null);
+        cs.store("#app1/subapp2?key3", createCredentialFromPassword("value3"), null);
+        cs.store("#app1/subapp3?key4", createCredentialFromPassword("value4"), null);
 
         Set<String> aliases = cs.getAliases("secret/app1", true, 1);
 
-        assertTrue(aliases.contains("secret/app1.key1"));
-        assertTrue(aliases.contains("secret/app1/subapp1.key2"));
-        assertTrue(aliases.contains("secret/app1/subapp2.key3"));
-        assertTrue(aliases.contains("secret/app1/subapp3.key4"));
+        assertTrue(aliases.contains("#app1?key1"));
+        assertTrue(aliases.contains("#app1/subapp1?key2"));
+        assertTrue(aliases.contains("#app1/subapp2?key3"));
+        assertTrue(aliases.contains("#app1/subapp3?key4"));
         assertEquals(4, aliases.size());
     }
 
@@ -279,13 +279,13 @@ public class HashicorpVaultCredentialStoreTestCase {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
 
-        cs.store("secret/app1.key1", createCredentialFromPassword("value1"), null);
-        cs.store("secret/app1/subapp1/deep.key2", createCredentialFromPassword("value2"), null);
+        cs.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        cs.store("#app1/subapp1/deep?key2", createCredentialFromPassword("value2"), null);
 
         Set<String> aliases = cs.getAliases("secret/app1", true, 2);
 
-        assertTrue(aliases.contains("secret/app1.key1"));
-        assertTrue(aliases.contains("secret/app1/subapp1/deep.key2"));
+        assertTrue(aliases.contains("#app1?key1"));
+        assertTrue(aliases.contains("#app1/subapp1/deep?key2"));
     }
 
     /**
@@ -296,16 +296,16 @@ public class HashicorpVaultCredentialStoreTestCase {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
 
-        cs.store("secret/app1.key1", createCredentialFromPassword("value1"), null);
-        cs.store("secret/app1.key2", createCredentialFromPassword("value2"), null);
-        cs.store("secret/app1/subapp1.key3", createCredentialFromPassword("value3"), null);
-        cs.store("secret/app1/subapp1.key4", createCredentialFromPassword("value4"), null);
-        cs.store("secret/app1/subapp2.key5", createCredentialFromPassword("value5"), null);
-        cs.store("secret/app1/subapp2.key6", createCredentialFromPassword("value6"), null);
+        cs.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        cs.store("#app1?key2", createCredentialFromPassword("value2"), null);
+        cs.store("#app1/subapp1?key3", createCredentialFromPassword("value3"), null);
+        cs.store("#app1/subapp1?key4", createCredentialFromPassword("value4"), null);
+        cs.store("#app1/subapp2?key5", createCredentialFromPassword("value5"), null);
+        cs.store("#app1/subapp2?key6", createCredentialFromPassword("value6"), null);
 
         Set<String> aliases = cs.getAliases("secret/app1", true, 1, 3);
-        assertTrue(aliases.contains("secret/app1.key1"));
-        assertTrue(aliases.contains("secret/app1.key2"));
+        assertTrue(aliases.contains("#app1?key1"));
+        assertTrue(aliases.contains("#app1?key2"));
         assertEquals(3, aliases.size());
     }
 
@@ -317,14 +317,14 @@ public class HashicorpVaultCredentialStoreTestCase {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
 
-        cs.store("secret/app1.key1", createCredentialFromPassword("value1"), null);
-        cs.store("secret/app1/subapp1.key2", createCredentialFromPassword("value2"), null);
-        cs.store("secret/app1/subapp1/deep.key3", createCredentialFromPassword("value3"), null);
-        cs.store("secret/app1/subapp2.key4", createCredentialFromPassword("value4"), null);
+        cs.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        cs.store("#app1/subapp1?key2", createCredentialFromPassword("value2"), null);
+        cs.store("#app1/subapp1/deep?key3", createCredentialFromPassword("value3"), null);
+        cs.store("#app1/subapp2?key4", createCredentialFromPassword("value4"), null);
 
         Set<String> aliases = cs.getAliases("secret/app1", true, 2, 2);
 
-        assertTrue(aliases.contains("secret/app1.key1"));
+        assertTrue(aliases.contains("#app1?key1"));
         assertEquals(2, aliases.size());
     }
 
@@ -336,14 +336,14 @@ public class HashicorpVaultCredentialStoreTestCase {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore cs = createHashicorpVaultCredentialStore();
 
-        cs.store("secret/app1.key1", createCredentialFromPassword("value1"), null);
-        cs.store("secret/app1.key2", createCredentialFromPassword("value2"), null);
-        cs.store("secret/app1/subapp1.key3", createCredentialFromPassword("value3"), null);
+        cs.store("#app1?key1", createCredentialFromPassword("value1"), null);
+        cs.store("#app1?key2", createCredentialFromPassword("value2"), null);
+        cs.store("#app1/subapp1?key3", createCredentialFromPassword("value3"), null);
         Set<String> aliases = cs.getAliases("secret/app1", false, 10, 1);
 
         assertEquals(1, aliases.size());
-        assertTrue(aliases.contains("secret/app1.key1") || aliases.contains("secret/app1.key2"));
-        assertFalse(aliases.contains("secret/app1/subapp1.key3"));
+        assertTrue(aliases.contains("#app1?key1") || aliases.contains("#app1?key2"));
+        assertFalse(aliases.contains("#app1/subapp1?key3"));
     }
 
     /**
@@ -353,10 +353,10 @@ public class HashicorpVaultCredentialStoreTestCase {
     public void testCredentialCacheHit() throws Exception {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore store = createHashicorpVaultCredentialStore();
-        PasswordCredential first = store.retrieve("secret/testing1.top_secret", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
+        PasswordCredential first = store.retrieve("#testing1?top_secret", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
         assertNotNull(first);
         assertEquals("password123", String.valueOf(first.getPassword(ClearPassword.class).getPassword()));
-        PasswordCredential second = store.retrieve("secret/testing1.top_secret", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
+        PasswordCredential second = store.retrieve("#testing1?top_secret", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
         assertSame(first, second);
     }
 
@@ -367,11 +367,11 @@ public class HashicorpVaultCredentialStoreTestCase {
     public void testCredentialCacheInvalidationOnStore() throws Exception {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore store = createHashicorpVaultCredentialStore();
-        store.store("secret/cachetest.key1", createCredentialFromPassword("value1"), null);
-        PasswordCredential c1 = store.retrieve("secret/cachetest.key1", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
+        store.store("#cachetest?key1", createCredentialFromPassword("value1"), null);
+        PasswordCredential c1 = store.retrieve("#cachetest?key1", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
         assertEquals("value1", String.valueOf(c1.getPassword(ClearPassword.class).getPassword()));
-        store.store("secret/cachetest.key1", createCredentialFromPassword("value2"), null);
-        PasswordCredential c2 = store.retrieve("secret/cachetest.key1", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
+        store.store("#cachetest?key1", createCredentialFromPassword("value2"), null);
+        PasswordCredential c2 = store.retrieve("#cachetest?key1", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
         assertEquals("value2", String.valueOf(c2.getPassword(ClearPassword.class).getPassword()));
     }
 
@@ -382,12 +382,12 @@ public class HashicorpVaultCredentialStoreTestCase {
     public void testCredentialCacheInvalidationOnRemove() throws Exception {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore store = createHashicorpVaultCredentialStore();
-        store.store("secret/cachetest.a", createCredentialFromPassword("a"), null);
-        store.store("secret/cachetest.b", createCredentialFromPassword("b"), null);
-        store.retrieve("secret/cachetest.a", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
-        store.remove("secret/cachetest.a", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null);
-        assertNull(store.retrieve("secret/cachetest.a", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot")));
-        PasswordCredential b = store.retrieve("secret/cachetest.b", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
+        store.store("#cachetest?a", createCredentialFromPassword("a"), null);
+        store.store("#cachetest?b", createCredentialFromPassword("b"), null);
+        store.retrieve("#cachetest?a", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
+        store.remove("#cachetest?a", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null);
+        assertNull(store.retrieve("#cachetest?a", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot")));
+        PasswordCredential b = store.retrieve("#cachetest?b", PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, createProtectionParameter("myroot"));
         assertEquals("b", String.valueOf(b.getPassword(ClearPassword.class).getPassword()));
     }
 
@@ -455,7 +455,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         vaultTestContainer = startVaultTestContainer();
         HashicorpVaultCredentialStore store = createHashicorpVaultCredentialStore();
         assertThrows(CredentialStoreException.class,
-                () -> store.store("secret/path.key", null, null));
+                () -> store.store("#path?key", null, null));
     }
 
     /**
@@ -710,7 +710,7 @@ public class HashicorpVaultCredentialStoreTestCase {
     public void testStoreNotInitialized() {
         HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
         assertThrows(CredentialStoreException.class,
-                () -> store.store("secret/path.key", createCredentialFromPassword("v"), null));
+                () -> store.store("#path?key", createCredentialFromPassword("v"), null));
     }
 
     /**
@@ -721,7 +721,7 @@ public class HashicorpVaultCredentialStoreTestCase {
     public void testRetrieveNotInitialized() {
         HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
         assertThrows(CredentialStoreException.class,
-                () -> store.retrieve("secret/path.key", PasswordCredential.class,
+                () -> store.retrieve("#path?key", PasswordCredential.class,
                         ClearPassword.ALGORITHM_CLEAR, null, null));
     }
 
@@ -733,7 +733,7 @@ public class HashicorpVaultCredentialStoreTestCase {
     public void testRemoveNotInitialized() {
         HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
         assertThrows(CredentialStoreException.class,
-                () -> store.remove("secret/path.key", PasswordCredential.class,
+                () -> store.remove("#path?key", PasswordCredential.class,
                         ClearPassword.ALGORITHM_CLEAR, null));
     }
 

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
@@ -4,6 +4,22 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wildfly.security.hashicorp.vault.VaultTestUtils.startVaultTestContainer;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.spec.InvalidKeySpecException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,22 +35,6 @@ import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.WildFlyElytronPasswordProvider;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
-
-import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
-import java.security.spec.InvalidKeySpecException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.wildfly.security.hashicorp.vault.VaultTestUtils.startVaultTestContainer;
 
 public class HashicorpVaultCredentialStoreTestCase {
 
@@ -179,7 +179,7 @@ public class HashicorpVaultCredentialStoreTestCase {
 
         Set<String> aliases1 = cs.getAliases("secret/testing1");
         Set<String> aliases2 = cs.getAliases("secret/testing1", false, 0);
-        
+
         assertEquals(aliases1, aliases2);
         assertTrue(aliases2.contains("secret/testing1.top_secret"));
     }
@@ -197,7 +197,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.store("secret/app1/subapp.key3", createCredentialFromPassword("value3"), null);
 
         Set<String> aliases = cs.getAliases("secret/app1", true, 0);
-        
+
         assertTrue(aliases.contains("secret/app1.key1"));
         assertTrue(aliases.contains("secret/app1.key2"));
         // Should NOT include any subpath keys when depth is 0
@@ -340,7 +340,7 @@ public class HashicorpVaultCredentialStoreTestCase {
         cs.store("secret/app1.key2", createCredentialFromPassword("value2"), null);
         cs.store("secret/app1/subapp1.key3", createCredentialFromPassword("value3"), null);
         Set<String> aliases = cs.getAliases("secret/app1", false, 10, 1);
-        
+
         assertEquals(1, aliases.size());
         assertTrue(aliases.contains("secret/app1.key1") || aliases.contains("secret/app1.key2"));
         assertFalse(aliases.contains("secret/app1/subapp1.key3"));

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTlsAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTlsAuthTestCase.java
@@ -157,9 +157,11 @@ public class HashicorpVaultCredentialStoreTlsAuthTestCase {
             store.setSslContext(wrongSslContext);
             Map<String, String> attributes = new HashMap<>();
             attributes.put("host-address", vaultTestContainer.composeHttpsHostAddress());
+            store.initialize(attributes, null, new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
+            // Exception should be thrown when attempting to use the store
             assertThrows(CredentialStoreException.class,
-                    () -> store.initialize(attributes, null,
-                            new Provider[]{WildFlyElytronPasswordProvider.getInstance()}));
+                    () -> store.retrieve("secret/testing1.top_secret", PasswordCredential.class,
+                            ClearPassword.ALGORITHM_CLEAR, null, null));
         } finally {
             VaultTestUtils.cleanupDir(wrongCertDir);
         }
@@ -178,9 +180,11 @@ public class HashicorpVaultCredentialStoreTlsAuthTestCase {
         store.setSslContext(trustOnlyContext);
         Map<String, String> attributes = new HashMap<>();
         attributes.put("host-address", vaultTestContainer.composeHttpsHostAddress());
+        store.initialize(attributes, null, new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
+        // Exception should be thrown when attempting to use the store
         assertThrows(CredentialStoreException.class,
-                () -> store.initialize(attributes, null,
-                        new Provider[]{WildFlyElytronPasswordProvider.getInstance()}));
+                () -> store.retrieve("secret/testing1.top_secret", PasswordCredential.class,
+                        ClearPassword.ALGORITHM_CLEAR, null, null));
     }
 
     private HashicorpVaultCredentialStore createStoreWithCertAuth(

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTlsAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTlsAuthTestCase.java
@@ -4,11 +4,20 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.smallrye.certs.CertificateFiles;
-import io.smallrye.certs.CertificateGenerator;
-import io.smallrye.certs.CertificateRequest;
-import io.smallrye.certs.Format;
-import io.smallrye.certs.PemCertificateFiles;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.Provider;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,18 +33,11 @@ import org.wildfly.security.password.WildFlyElytronPasswordProvider;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 
-import javax.net.ssl.SSLContext;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.security.Provider;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.smallrye.certs.CertificateFiles;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.PemCertificateFiles;
 
 /**
  * Tests that {@link HashicorpVaultCredentialStore} works with TLS certificate authentication,

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTlsAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTlsAuthTestCase.java
@@ -86,7 +86,7 @@ public class HashicorpVaultCredentialStoreTlsAuthTestCase {
     @Test
     public void testCertAuthWithNullProtectionParameter() throws Exception {
         HashicorpVaultCredentialStore store = createStoreWithCertAuth(null);
-        PasswordCredential credential = store.retrieve("secret/testing1.top_secret",
+        PasswordCredential credential = store.retrieve("#testing1?top_secret",
                 PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, null);
         assertNotNull(credential);
         assertEquals("password123", String.valueOf(credential.getPassword(ClearPassword.class).getPassword()));
@@ -101,7 +101,7 @@ public class HashicorpVaultCredentialStoreTlsAuthTestCase {
     public void testCertAuthWithWhitespaceToken(String token) throws Exception {
         HashicorpVaultCredentialStore store = createStoreWithCertAuth(
                 createProtectionParameter(token));
-        PasswordCredential credential = store.retrieve("secret/testing1.top_secret",
+        PasswordCredential credential = store.retrieve("#testing1?top_secret",
                 PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, null);
         assertNotNull(credential);
         assertEquals("password123", String.valueOf(credential.getPassword(ClearPassword.class).getPassword()));
@@ -116,17 +116,17 @@ public class HashicorpVaultCredentialStoreTlsAuthTestCase {
         HashicorpVaultCredentialStore store = createStoreWithCertAuth(null);
 
         PasswordCredential credential = createCredentialFromPassword("mySecretValue");
-        store.store("secret/certtest.password", credential, null);
+        store.store("#certtest?password", credential, null);
 
-        PasswordCredential retrieved = store.retrieve("secret/certtest.password",
+        PasswordCredential retrieved = store.retrieve("#certtest?password",
                 PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, null);
         assertNotNull(retrieved);
         assertEquals("mySecretValue", String.valueOf(retrieved.getPassword(ClearPassword.class).getPassword()));
 
-        store.remove("secret/certtest.password", PasswordCredential.class,
+        store.remove("#certtest?password", PasswordCredential.class,
                 ClearPassword.ALGORITHM_CLEAR, null);
 
-        PasswordCredential afterRemove = store.retrieve("secret/certtest.password",
+        PasswordCredential afterRemove = store.retrieve("#certtest?password",
                 PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR, null, null);
         assertNull(afterRemove);
     }
@@ -160,7 +160,7 @@ public class HashicorpVaultCredentialStoreTlsAuthTestCase {
             store.initialize(attributes, null, new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
             // Exception should be thrown when attempting to use the store
             assertThrows(CredentialStoreException.class,
-                    () -> store.retrieve("secret/testing1.top_secret", PasswordCredential.class,
+                    () -> store.retrieve("#testing1?top_secret", PasswordCredential.class,
                             ClearPassword.ALGORITHM_CLEAR, null, null));
         } finally {
             VaultTestUtils.cleanupDir(wrongCertDir);
@@ -183,7 +183,7 @@ public class HashicorpVaultCredentialStoreTlsAuthTestCase {
         store.initialize(attributes, null, new Provider[]{WildFlyElytronPasswordProvider.getInstance()});
         // Exception should be thrown when attempting to use the store
         assertThrows(CredentialStoreException.class,
-                () -> store.retrieve("secret/testing1.top_secret", PasswordCredential.class,
+                () -> store.retrieve("#testing1?top_secret", PasswordCredential.class,
                         ClearPassword.ALGORITHM_CLEAR, null, null));
     }
 

--- a/src/test/java/org/wildfly/security/hashicorp/vault/JwtConfigTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/JwtConfigTestCase.java
@@ -4,13 +4,13 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit tests for {@link JwtConfig} constructor validation and getters.

--- a/src/test/java/org/wildfly/security/hashicorp/vault/KeyPathResolverTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/KeyPathResolverTestCase.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wildfly.security.credential.store.CredentialStoreException;
+
+/**
+ * Unit tests for {@link KeyPathResolver} key path resolution logic.
+ *
+ * <p>This test class covers:
+ * <ul>
+ *   <li>Simple key lookups (with and without dots in key names)</li>
+ *   <li>Nested JSON path traversal (single and multi-level)</li>
+ *   <li>Mixed scenarios (nested paths with dots in key names)</li>
+ *   <li>Edge cases (empty paths, non-existent keys, non-map values, null values)</li>
+ *   <li>Set and remove operations for nested values</li>
+ * </ul>
+ *
+ * <p>Test coverage target: >95% for {@link KeyPathResolver} class
+ */
+public class KeyPathResolverTestCase {
+
+    private Map<String, Object> testData;
+
+    @BeforeEach
+    void setUp() {
+        // Create test data structure matching the specification
+        Map<String, Object> credentials = new HashMap<>();
+        credentials.put("user", "admin");
+        credentials.put("pass", "secret");
+
+        Map<String, Object> database = new HashMap<>();
+        database.put("host", "prod.db.com");
+        database.put("port", 5432);
+        database.put("credentials", credentials);
+
+        Map<String, Object> myApp = new HashMap<>();
+        myApp.put("config.key", "value123");
+
+        testData = new HashMap<>();
+        testData.put("password", "secret123");
+        testData.put("db.host", "localhost");
+        testData.put("database", database);
+        testData.put("my.app", myApp);
+    }
+
+    // ========================================================================
+    // Simple Key Tests
+    // ========================================================================
+
+    @Test
+    void testSimpleKeyWithoutDots() throws CredentialStoreException {
+        // Top-level key without dots
+        String result = KeyPathResolver.resolveKeyPath(testData, "password");
+        assertEquals("secret123", result);
+    }
+
+    @Test
+    void testSimpleKeyWithDots() throws CredentialStoreException {
+        // Top-level key with dots - literal match
+        String result = KeyPathResolver.resolveKeyPath(testData, "db.host");
+        assertEquals("localhost", result);
+    }
+
+    @Test
+    void testSimpleKeyNotFound() throws CredentialStoreException {
+        // Key that doesn't exist
+        String result = KeyPathResolver.resolveKeyPath(testData, "nonexistent");
+        assertNull(result);
+    }
+
+    @Test
+    void testSimpleKeyWithDotsNotFound() throws CredentialStoreException {
+        // Key with dots that doesn't exist
+        String result = KeyPathResolver.resolveKeyPath(testData, "not.found");
+        assertNull(result);
+    }
+
+    // ========================================================================
+    // Nested Path Tests
+    // ========================================================================
+
+    @Test
+    void testSingleLevelNesting() throws CredentialStoreException {
+        // Single-level nested path
+        String result = KeyPathResolver.resolveKeyPath(testData, "database/host");
+        assertEquals("prod.db.com", result);
+    }
+
+    @Test
+    void testSingleLevelNestingInteger() throws CredentialStoreException {
+        // Single-level nested path with integer value
+        String result = KeyPathResolver.resolveKeyPath(testData, "database/port");
+        assertEquals("5432", result);
+    }
+
+    @Test
+    void testMultiLevelNesting() throws CredentialStoreException {
+        // Multi-level nested path (2 levels)
+        String result = KeyPathResolver.resolveKeyPath(testData, "database/credentials/user");
+        assertEquals("admin", result);
+    }
+
+    @Test
+    void testDeepNesting() throws CredentialStoreException {
+        // Deep nesting (3 levels)
+        String result = KeyPathResolver.resolveKeyPath(testData, "database/credentials/pass");
+        assertEquals("secret", result);
+    }
+
+    @Test
+    void testNestedPathNotFound() throws CredentialStoreException {
+        // Nested path where intermediate key doesn't exist
+        String result = KeyPathResolver.resolveKeyPath(testData, "database/nonexistent/key");
+        assertNull(result);
+    }
+
+    @Test
+    void testNestedPathLeafNotFound() throws CredentialStoreException {
+        // Nested path where leaf key doesn't exist
+        String result = KeyPathResolver.resolveKeyPath(testData, "database/credentials/nonexistent");
+        assertNull(result);
+    }
+
+    // ========================================================================
+    // Mixed Tests (Nested Paths with Dots in Key Names)
+    // ========================================================================
+
+    @Test
+    void testNestedPathWithDotsInKeyName() throws CredentialStoreException {
+        // Nested path where segment contains dots
+        String result = KeyPathResolver.resolveKeyPath(testData, "my.app/config.key");
+        assertEquals("value123", result);
+    }
+
+    @Test
+    void testComplexNestedWithDots() throws CredentialStoreException {
+        // Add more complex nested structure with dots
+        Map<String, Object> teamAlpha = new HashMap<>();
+        teamAlpha.put("app.config", "alpha-value");
+        testData.put("team.alpha", teamAlpha);
+
+        String result = KeyPathResolver.resolveKeyPath(testData, "team.alpha/app.config");
+        assertEquals("alpha-value", result);
+    }
+
+    // ========================================================================
+    // Edge Cases
+    // ========================================================================
+
+    @Test
+    void testNullKeyPath() {
+        // Null key path should throw exception
+        assertThrows(CredentialStoreException.class, () -> {
+            KeyPathResolver.resolveKeyPath(testData, null);
+        });
+    }
+
+    @Test
+    void testEmptyKeyPath() {
+        // Empty key path should throw exception
+        assertThrows(CredentialStoreException.class, () -> {
+            KeyPathResolver.resolveKeyPath(testData, "");
+        });
+    }
+
+    @Test
+    void testNullData() throws CredentialStoreException {
+        // Null data map should return null
+        String result = KeyPathResolver.resolveKeyPath(null, "password");
+        assertNull(result);
+    }
+
+    @Test
+    void testEmptySegmentInPath() {
+        // Key path with empty segment (e.g., "database//host")
+        assertThrows(CredentialStoreException.class, () -> {
+            KeyPathResolver.resolveKeyPath(testData, "database//host");
+        });
+    }
+
+    @Test
+    void testLeadingSlash() {
+        // Key path starting with slash
+        assertThrows(CredentialStoreException.class, () -> {
+            KeyPathResolver.resolveKeyPath(testData, "/database/host");
+        });
+    }
+
+    @Test
+    void testTrailingSlash() throws CredentialStoreException {
+        // Key path ending with slash - trailing empty strings are removed by split()
+        // so this is equivalent to "database/host"
+        String result = KeyPathResolver.resolveKeyPath(testData, "database/host/");
+        assertEquals("prod.db.com", result);
+    }
+
+    @Test
+    void testNonMapValueInTraversalPath() throws CredentialStoreException {
+        // Try to traverse through a non-map value
+        String result = KeyPathResolver.resolveKeyPath(testData, "password/subkey");
+        assertNull(result);
+    }
+
+    @Test
+    void testNonMapIntermediateValue() throws CredentialStoreException {
+        // Try to traverse through an integer value
+        String result = KeyPathResolver.resolveKeyPath(testData, "database/port/subkey");
+        assertNull(result);
+    }
+
+    @Test
+    void testNullValueInData() throws CredentialStoreException {
+        // Add null value to test data
+        testData.put("nullValue", null);
+        String result = KeyPathResolver.resolveKeyPath(testData, "nullValue");
+        assertNull(result);
+    }
+
+    @Test
+    void testNullValueInNestedPath() throws CredentialStoreException {
+        // Add null value in nested structure
+        Map<String, Object> database = (Map<String, Object>) testData.get("database");
+        database.put("nullField", null);
+
+        String result = KeyPathResolver.resolveKeyPath(testData, "database/nullField");
+        assertNull(result);
+    }
+
+    // ========================================================================
+    // Set Nested Value Tests
+    // ========================================================================
+
+    @Test
+    void testSetSimpleValue() throws CredentialStoreException {
+        Map<String, Object> data = new HashMap<>();
+        KeyPathResolver.setNestedValue(data, "password", "newSecret");
+
+        assertEquals("newSecret", data.get("password"));
+    }
+
+    @Test
+    void testSetNestedValueCreatesStructure() throws CredentialStoreException {
+        Map<String, Object> data = new HashMap<>();
+        KeyPathResolver.setNestedValue(data, "database/host", "localhost");
+
+        assertTrue(data.containsKey("database"));
+        assertTrue(data.get("database") instanceof Map);
+        Map<String, Object> database = (Map<String, Object>) data.get("database");
+        assertEquals("localhost", database.get("host"));
+    }
+
+    @Test
+    void testSetDeepNestedValue() throws CredentialStoreException {
+        Map<String, Object> data = new HashMap<>();
+        KeyPathResolver.setNestedValue(data, "database/credentials/password", "secret");
+
+        Map<String, Object> database = (Map<String, Object>) data.get("database");
+        Map<String, Object> credentials = (Map<String, Object>) database.get("credentials");
+        assertEquals("secret", credentials.get("password"));
+    }
+
+    @Test
+    void testSetValueWithDotsInSegment() throws CredentialStoreException {
+        Map<String, Object> data = new HashMap<>();
+        KeyPathResolver.setNestedValue(data, "my.app/config.key", "value");
+
+        assertTrue(data.containsKey("my.app"));
+        Map<String, Object> myApp = (Map<String, Object>) data.get("my.app");
+        assertEquals("value", myApp.get("config.key"));
+    }
+
+    @Test
+    void testSetValueReplacesNonMapValue() throws CredentialStoreException {
+        Map<String, Object> data = new HashMap<>();
+        data.put("database", "stringValue");
+
+        KeyPathResolver.setNestedValue(data, "database/host", "localhost");
+
+        assertTrue(data.get("database") instanceof Map);
+        Map<String, Object> database = (Map<String, Object>) data.get("database");
+        assertEquals("localhost", database.get("host"));
+    }
+
+    @Test
+    void testSetValueNullKeyPath() {
+        Map<String, Object> data = new HashMap<>();
+        assertThrows(CredentialStoreException.class, () -> {
+            KeyPathResolver.setNestedValue(data, null, "value");
+        });
+    }
+
+    @Test
+    void testSetValueEmptyKeyPath() {
+        Map<String, Object> data = new HashMap<>();
+        assertThrows(CredentialStoreException.class, () -> {
+            KeyPathResolver.setNestedValue(data, "", "value");
+        });
+    }
+
+    @Test
+    void testSetValueNullData() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            KeyPathResolver.setNestedValue(null, "key", "value");
+        });
+    }
+
+    @Test
+    void testSetValueEmptySegment() {
+        Map<String, Object> data = new HashMap<>();
+        assertThrows(CredentialStoreException.class, () -> {
+            KeyPathResolver.setNestedValue(data, "database//host", "value");
+        });
+    }
+
+    // ========================================================================
+    // Remove Nested Value Tests
+    // ========================================================================
+
+    @Test
+    void testRemoveSimpleValue() throws CredentialStoreException {
+        Map<String, Object> data = new HashMap<>();
+        data.put("password", "secret");
+
+        boolean removed = KeyPathResolver.removeNestedValue(data, "password");
+        assertTrue(removed);
+        assertFalse(data.containsKey("password"));
+    }
+
+    @Test
+    void testRemoveNestedValue() throws CredentialStoreException {
+        Map<String, Object> credentials = new HashMap<>();
+        credentials.put("user", "admin");
+        credentials.put("pass", "secret");
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("credentials", credentials);
+
+        boolean removed = KeyPathResolver.removeNestedValue(data, "credentials/pass");
+        assertTrue(removed);
+        assertFalse(credentials.containsKey("pass"));
+        assertTrue(credentials.containsKey("user")); // Other keys preserved
+    }
+
+    @Test
+    void testRemoveDeepNestedValue() throws CredentialStoreException {
+        boolean removed = KeyPathResolver.removeNestedValue(testData, "database/credentials/pass");
+        assertTrue(removed);
+
+        Map<String, Object> database = (Map<String, Object>) testData.get("database");
+        Map<String, Object> credentials = (Map<String, Object>) database.get("credentials");
+        assertFalse(credentials.containsKey("pass"));
+        assertTrue(credentials.containsKey("user")); // Other keys preserved
+    }
+
+    @Test
+    void testRemoveNonExistentSimpleKey() throws CredentialStoreException {
+        boolean removed = KeyPathResolver.removeNestedValue(testData, "nonexistent");
+        assertFalse(removed);
+    }
+
+    @Test
+    void testRemoveNonExistentNestedKey() throws CredentialStoreException {
+        boolean removed = KeyPathResolver.removeNestedValue(testData, "database/nonexistent");
+        assertFalse(removed);
+    }
+
+    @Test
+    void testRemoveFromNonExistentPath() throws CredentialStoreException {
+        boolean removed = KeyPathResolver.removeNestedValue(testData, "nonexistent/path/key");
+        assertFalse(removed);
+    }
+
+    @Test
+    void testRemoveFromNonMapValue() throws CredentialStoreException {
+        boolean removed = KeyPathResolver.removeNestedValue(testData, "password/subkey");
+        assertFalse(removed);
+    }
+
+    @Test
+    void testRemoveNullKeyPath() {
+        assertThrows(CredentialStoreException.class, () -> {
+            KeyPathResolver.removeNestedValue(testData, null);
+        });
+    }
+
+    @Test
+    void testRemoveEmptyKeyPath() {
+        assertThrows(CredentialStoreException.class, () -> {
+            KeyPathResolver.removeNestedValue(testData, "");
+        });
+    }
+
+    @Test
+    void testRemoveNullData() throws CredentialStoreException {
+        boolean removed = KeyPathResolver.removeNestedValue(null, "key");
+        assertFalse(removed);
+    }
+
+    @Test
+    void testRemoveEmptySegment() {
+        assertThrows(CredentialStoreException.class, () -> {
+            KeyPathResolver.removeNestedValue(testData, "database//host");
+        });
+    }
+
+    // ========================================================================
+    // Additional Edge Cases
+    // ========================================================================
+
+    @Test
+    void testVeryDeepNesting() throws CredentialStoreException {
+        // Create a very deep nested structure (5 levels)
+        Map<String, Object> level5 = new HashMap<>();
+        level5.put("value", "deep");
+
+        Map<String, Object> level4 = new HashMap<>();
+        level4.put("level5", level5);
+
+        Map<String, Object> level3 = new HashMap<>();
+        level3.put("level4", level4);
+
+        Map<String, Object> level2 = new HashMap<>();
+        level2.put("level3", level3);
+
+        Map<String, Object> level1 = new HashMap<>();
+        level1.put("level2", level2);
+
+        testData.put("level1", level1);
+
+        String result = KeyPathResolver.resolveKeyPath(testData, "level1/level2/level3/level4/level5/value");
+        assertEquals("deep", result);
+    }
+
+    @Test
+    void testSpecialCharactersInKeyName() throws CredentialStoreException {
+        // Keys can contain special characters (already URL-decoded at this point)
+        testData.put("key with spaces", "value1");
+        testData.put("key#with#hash", "value2");
+        testData.put("key?with?question", "value3");
+
+        assertEquals("value1", KeyPathResolver.resolveKeyPath(testData, "key with spaces"));
+        assertEquals("value2", KeyPathResolver.resolveKeyPath(testData, "key#with#hash"));
+        assertEquals("value3", KeyPathResolver.resolveKeyPath(testData, "key?with?question"));
+    }
+
+    @Test
+    void testBooleanValue() throws CredentialStoreException {
+        testData.put("enabled", true);
+        String result = KeyPathResolver.resolveKeyPath(testData, "enabled");
+        assertEquals("true", result);
+    }
+
+    @Test
+    void testNumericValue() throws CredentialStoreException {
+        testData.put("count", 42);
+        String result = KeyPathResolver.resolveKeyPath(testData, "count");
+        assertEquals("42", result);
+    }
+
+    @Test
+    void testDoubleValue() throws CredentialStoreException {
+        testData.put("price", 19.99);
+        String result = KeyPathResolver.resolveKeyPath(testData, "price");
+        assertEquals("19.99", result);
+    }
+}

--- a/src/test/java/org/wildfly/security/hashicorp/vault/KvVersionTestHelper.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/KvVersionTestHelper.java
@@ -275,5 +275,3 @@ public class KvVersionTestHelper {
         throw new IllegalStateException("Vault container did not become ready within " + maxWaitSeconds + " seconds");
     }
 }
-
-// Made with Bob

--- a/src/test/java/org/wildfly/security/hashicorp/vault/KvVersionTestHelper.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/KvVersionTestHelper.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import org.testcontainers.containers.Container;
+import org.testcontainers.vault.VaultContainer;
+
+import java.io.IOException;
+
+/**
+ * Helper utilities for KV version testing.
+ *
+ * <p>This class provides common functionality for testing HashiCorp Vault KV Secrets Engine
+ * versions (v1 and v2), including CLI command execution, path validation, and test data setup.
+ */
+public class KvVersionTestHelper {
+
+    /**
+     * Represents the KV engine version.
+     */
+    public enum KvVersion {
+        V1(1, "KV v1"),
+        V2(2, "KV v2");
+
+        private final int version;
+        private final String displayName;
+
+        KvVersion(int version, String displayName) {
+            this.version = version;
+            this.displayName = displayName;
+        }
+
+        public int getVersion() {
+            return version;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        @Override
+        public String toString() {
+            return displayName;
+        }
+    }
+
+    /**
+     * Configuration for a KV version test scenario.
+     */
+    public static class KvTestConfig {
+        private final VaultContainer<?> container;
+        private final String mountPath;
+        private final KvVersion version;
+        private final String token;
+
+        public KvTestConfig(VaultContainer<?> container, String mountPath, KvVersion version, String token) {
+            this.container = container;
+            this.mountPath = mountPath;
+            this.version = version;
+            this.token = token;
+        }
+
+        public VaultContainer<?> getContainer() {
+            return container;
+        }
+
+        public String getMountPath() {
+            return mountPath;
+        }
+
+        public KvVersion getVersion() {
+            return version;
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public String getHostAddress() {
+            return container.getHttpHostAddress();
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s (mount: %s)", version.getDisplayName(), mountPath);
+        }
+    }
+
+    /**
+     * Executes a Vault CLI command in the container.
+     *
+     * @param container the Vault container
+     * @param command the CLI command arguments (e.g., "kv", "get", "secret/path")
+     * @return the command execution result
+     * @throws IOException if command execution fails
+     * @throws InterruptedException if command execution is interrupted
+     */
+    public static Container.ExecResult execVaultCommand(VaultContainer<?> container, String... command)
+            throws IOException, InterruptedException {
+        String[] fullCommand = new String[command.length + 1];
+        fullCommand[0] = "vault";
+        System.arraycopy(command, 0, fullCommand, 1, command.length);
+        return container.execInContainer(fullCommand);
+    }
+
+    /**
+     * Writes a secret using the Vault CLI.
+     *
+     * @param container the Vault container
+     * @param path the secret path (e.g., "secret/myapp")
+     * @param keyValuePairs key-value pairs in the format "key=value"
+     * @return the command execution result
+     * @throws IOException if command execution fails
+     * @throws InterruptedException if command execution is interrupted
+     */
+    public static Container.ExecResult cliPutSecret(VaultContainer<?> container, String path, String... keyValuePairs)
+            throws IOException, InterruptedException {
+        String[] command = new String[keyValuePairs.length + 3];
+        command[0] = "kv";
+        command[1] = "put";
+        command[2] = path;
+        System.arraycopy(keyValuePairs, 0, command, 3, keyValuePairs.length);
+        return execVaultCommand(container, command);
+    }
+
+    /**
+     * Reads a secret using the Vault CLI.
+     *
+     * @param container the Vault container
+     * @param path the secret path (e.g., "secret/myapp")
+     * @return the command execution result
+     * @throws IOException if command execution fails
+     * @throws InterruptedException if command execution is interrupted
+     */
+    public static Container.ExecResult cliGetSecret(VaultContainer<?> container, String path)
+            throws IOException, InterruptedException {
+        return execVaultCommand(container, "kv", "get", "-format=json", path);
+    }
+
+    /**
+     * Deletes a secret using the Vault CLI.
+     *
+     * @param container the Vault container
+     * @param path the secret path (e.g., "secret/myapp")
+     * @return the command execution result
+     * @throws IOException if command execution fails
+     * @throws InterruptedException if command execution is interrupted
+     */
+    public static Container.ExecResult cliDeleteSecret(VaultContainer<?> container, String path)
+            throws IOException, InterruptedException {
+        return execVaultCommand(container, "kv", "delete", path);
+    }
+
+    /**
+     * Lists secrets at a path using the Vault CLI.
+     *
+     * @param container the Vault container
+     * @param path the secret path (e.g., "secret/")
+     * @return the command execution result
+     * @throws IOException if command execution fails
+     * @throws InterruptedException if command execution is interrupted
+     */
+    public static Container.ExecResult cliListSecrets(VaultContainer<?> container, String path)
+            throws IOException, InterruptedException {
+        return execVaultCommand(container, "kv", "list", "-format=json", path);
+    }
+
+    /**
+     * Constructs the API path for a secret based on KV version.
+     *
+     * <p>KV v1 uses direct paths: {@code /v1/secret/path/to/secret}
+     * <p>KV v2 uses data paths: {@code /v1/secret/data/path/to/secret}
+     *
+     * @param mountPath the mount path (e.g., "secret")
+     * @param secretPath the secret path relative to mount (e.g., "myapp/db")
+     * @param version the KV version
+     * @return the full API path
+     */
+    public static String constructApiPath(String mountPath, String secretPath, KvVersion version) {
+        if (version == KvVersion.V1) {
+            return mountPath + "/" + secretPath;
+        } else {
+            return mountPath + "/data/" + secretPath;
+        }
+    }
+
+    /**
+     * Constructs the metadata API path for a secret (KV v2 only).
+     *
+     * @param mountPath the mount path (e.g., "secret")
+     * @param secretPath the secret path relative to mount (e.g., "myapp/db")
+     * @return the metadata API path
+     * @throws IllegalArgumentException if called for KV v1
+     */
+    public static String constructMetadataPath(String mountPath, String secretPath) {
+        return mountPath + "/metadata/" + secretPath;
+    }
+
+    /**
+     * Validates that a secret path is correctly formatted for the given KV version.
+     *
+     * @param path the full secret path
+     * @param version the expected KV version
+     * @return true if the path format matches the version
+     */
+    public static boolean isValidPathForVersion(String path, KvVersion version) {
+        if (path == null || path.isEmpty()) {
+            return false;
+        }
+
+        if (version == KvVersion.V1) {
+            // KV v1 paths should NOT contain /data/ or /metadata/
+            return !path.contains("/data/") && !path.contains("/metadata/");
+        } else {
+            // KV v2 paths for data operations should contain /data/
+            // (metadata paths are handled separately)
+            return path.contains("/data/");
+        }
+    }
+
+    /**
+     * Extracts the secret name from a full path.
+     *
+     * @param path the full secret path (e.g., "secret/data/myapp" or "secret/myapp")
+     * @return the secret name (e.g., "myapp")
+     */
+    public static String extractSecretName(String path) {
+        if (path == null || path.isEmpty()) {
+            return "";
+        }
+
+        // Remove /data/ or /metadata/ if present
+        String normalized = path.replace("/data/", "/").replace("/metadata/", "/");
+
+        // Get the last segment
+        int lastSlash = normalized.lastIndexOf('/');
+        return lastSlash >= 0 ? normalized.substring(lastSlash + 1) : normalized;
+    }
+
+    /**
+     * Creates a display name for parameterized tests.
+     *
+     * @param config the test configuration
+     * @return a descriptive display name
+     */
+    public static String createDisplayName(KvTestConfig config) {
+        return String.format("[%s] mount=%s", config.getVersion().getDisplayName(), config.getMountPath());
+    }
+
+    /**
+     * Waits for the Vault container to be fully ready.
+     *
+     * @param container the Vault container
+     * @param maxWaitSeconds maximum time to wait in seconds
+     * @throws InterruptedException if waiting is interrupted
+     */
+    public static void waitForVaultReady(VaultContainer<?> container, int maxWaitSeconds)
+            throws InterruptedException {
+        int waited = 0;
+        while (waited < maxWaitSeconds) {
+            try {
+                Container.ExecResult result = execVaultCommand(container, "status");
+                if (result.getExitCode() == 0 || result.getExitCode() == 2) {
+                    // Exit code 0 = unsealed, 2 = sealed (both mean Vault is running)
+                    return;
+                }
+            } catch (IOException e) {
+                // Container not ready yet
+            }
+            Thread.sleep(1000);
+            waited++;
+        }
+        throw new IllegalStateException("Vault container did not become ready within " + maxWaitSeconds + " seconds");
+    }
+}
+
+// Made with Bob

--- a/src/test/java/org/wildfly/security/hashicorp/vault/LoginStrategyUnitTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/LoginStrategyUnitTestCase.java
@@ -4,7 +4,9 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.VaultException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -13,8 +15,7 @@ import org.wildfly.security.hashicorp.vault.loginstrategy.JwtLoginStrategy;
 import org.wildfly.security.hashicorp.vault.loginstrategy.LoginContext;
 import org.wildfly.security.hashicorp.vault.loginstrategy.TokenLoginStrategy;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.github.jopenlibs.vault.VaultException;
 
 /**
  * Unit tests for {@link TokenLoginStrategy} and {@link JwtLoginStrategy}.

--- a/src/test/java/org/wildfly/security/hashicorp/vault/SslContextTestHelper.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/SslContextTestHelper.java
@@ -4,11 +4,6 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyFactory;
@@ -23,6 +18,12 @@ import java.util.Base64;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 
 /**
  * Test utility to build {@link SSLContext} from PEM files so that tests can verify

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultAliasParsingTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultAliasParsingTestCase.java
@@ -354,6 +354,34 @@ public class VaultAliasParsingTestCase {
 
         assertNotNull(ex.getMessage());
     }
+    @Test
+    void testEngineTypeToVersionWithValidTypes() throws CredentialStoreException {
+        // Test valid engine types
+        VaultAlias aliasV1 = VaultAlias.parse("engine=KVv1#secret?key");
+        assertEquals(1, aliasV1.getKvVersion());
+
+        VaultAlias aliasV2 = VaultAlias.parse("engine=KVv2#secret?key");
+        assertEquals(2, aliasV2.getKvVersion());
+    }
+
+    @Test
+    void testEngineTypeToVersionWithInvalidType() {
+        // Test that engineTypeToVersion throws exception for invalid engine type
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.engineTypeToVersion("InvalidType"));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testEngineTypeToVersionWithNullType() {
+        // Test that engineTypeToVersion throws exception for null
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.engineTypeToVersion(null));
+
+        assertNotNull(ex.getMessage());
+    }
+
 
     // ========================================================================
     // Legacy Format Tests

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultAliasParsingTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultAliasParsingTestCase.java
@@ -44,6 +44,30 @@ public class VaultAliasParsingTestCase {
     }
 
     @Test
+    void testMinimalFormatWithoutHash() throws CredentialStoreException {
+        // Minimal format without # prefix: secret?key
+        VaultAlias alias = VaultAlias.parse("secret?key");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("secret", alias.getSecretPath());
+        assertEquals("key", alias.getKeyPath());
+    }
+
+    @Test
+    void testSecretPathWithSlashesWithoutHash() throws CredentialStoreException {
+        // Secret path with slashes, no # prefix: myapp/database?password
+        VaultAlias alias = VaultAlias.parse("myapp/database?password");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("myapp/database", alias.getSecretPath());
+        assertEquals("password", alias.getKeyPath());
+    }
+
+    @Test
     void testDotsInSecretPath() throws CredentialStoreException {
         // Dots in secret path: #my.app.config?password
         VaultAlias alias = VaultAlias.parse("#my.app.config?password");
@@ -247,12 +271,12 @@ public class VaultAliasParsingTestCase {
     // ========================================================================
 
     @Test
-    void testMissingHashBeforeSecretPath() {
-        // Missing # before secret path: secret?key
+    void testHashRequiredAfterMountPath() {
+        // When @ mount path is present, # is required before secret path
         CredentialStoreException ex = assertThrows(CredentialStoreException.class,
-            () -> VaultAlias.parse("secret?key"));
+            () -> VaultAlias.parse("@custom-mountsecret?key"));
 
-        // Should indicate invalid format
+        // Should indicate missing # delimiter
         assertNotNull(ex.getMessage());
     }
 

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultAliasParsingTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultAliasParsingTestCase.java
@@ -414,7 +414,7 @@ public class VaultAliasParsingTestCase {
     @Test
     void testSimpleLegacyFormat() throws CredentialStoreException {
         // Simple legacy format: myapp/db.password
-        VaultAlias alias = VaultAlias.parseWithLegacySupport(
+        VaultAlias alias = VaultAlias.parse(
             "myapp/db.password", "KVv2", "secret", true);
 
         assertNotNull(alias);
@@ -427,7 +427,7 @@ public class VaultAliasParsingTestCase {
     @Test
     void testLegacyWithDotsInSecretPath() throws CredentialStoreException {
         // Legacy with dots in secret path: app.config.key
-        VaultAlias alias = VaultAlias.parseWithLegacySupport(
+        VaultAlias alias = VaultAlias.parse(
             "app.config.key", "KVv2", "secret", true);
 
         assertNotNull(alias);
@@ -440,7 +440,7 @@ public class VaultAliasParsingTestCase {
     @Test
     void testLegacyWithMultipleDots() throws CredentialStoreException {
         // Legacy with multiple dots: my.app.db.password
-        VaultAlias alias = VaultAlias.parseWithLegacySupport(
+        VaultAlias alias = VaultAlias.parse(
             "my.app.db.password", "KVv2", "secret", true);
 
         assertNotNull(alias);
@@ -454,7 +454,7 @@ public class VaultAliasParsingTestCase {
     void testLegacyFormatNotSupportedThrowsException() {
         // Legacy format with support disabled should throw exception
         CredentialStoreException ex = assertThrows(CredentialStoreException.class,
-            () -> VaultAlias.parseWithLegacySupport(
+            () -> VaultAlias.parse(
                 "myapp/db.password", "KVv2", "secret", false));
 
         assertNotNull(ex.getMessage());
@@ -465,7 +465,7 @@ public class VaultAliasParsingTestCase {
     void testLegacyFormatWithoutDotThrowsException() {
         // Invalid legacy format (no dot): myapp
         CredentialStoreException ex = assertThrows(CredentialStoreException.class,
-            () -> VaultAlias.parseWithLegacySupport(
+            () -> VaultAlias.parse(
                 "myapp", "KVv2", "secret", true));
 
         assertNotNull(ex.getMessage());
@@ -474,7 +474,7 @@ public class VaultAliasParsingTestCase {
     @Test
     void testNewFormatNotTreatedAsLegacy() throws CredentialStoreException {
         // New format should not be treated as legacy even with legacy support enabled
-        VaultAlias alias = VaultAlias.parseWithLegacySupport(
+        VaultAlias alias = VaultAlias.parse(
             "#myapp?password", "KVv2", "secret", true);
 
         assertNotNull(alias);

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultAliasParsingTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultAliasParsingTestCase.java
@@ -1,0 +1,546 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.security.credential.store.CredentialStoreException;
+
+/**
+ * Unit tests for {@link VaultAlias} parsing logic.
+ *
+ * <p>This test class covers:
+ * <ul>
+ *   <li>Valid format parsing (simple keys, nested keys, URL encoding)</li>
+ *   <li>Invalid format detection and error messages</li>
+ *   <li>Legacy format support and deprecation</li>
+ *   <li>Default value application</li>
+ *   <li>Edge cases and special characters</li>
+ * </ul>
+ *
+ * <p>Test coverage target: >95% for {@link VaultAlias} class
+ */
+public class VaultAliasParsingTestCase {
+
+    // ========================================================================
+    // Valid Format Tests - Simple Keys
+    // ========================================================================
+
+    @Test
+    void testMinimalFormat() throws CredentialStoreException {
+        // Minimal format: #secret?key
+        VaultAlias alias = VaultAlias.parse("#secret?key");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("secret", alias.getSecretPath());
+        assertEquals("key", alias.getKeyPath());
+    }
+
+    @Test
+    void testDotsInSecretPath() throws CredentialStoreException {
+        // Dots in secret path: #my.app.config?password
+        VaultAlias alias = VaultAlias.parse("#my.app.config?password");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("my.app.config", alias.getSecretPath());
+        assertEquals("password", alias.getKeyPath());
+    }
+
+    @Test
+    void testDotsInKeyName() throws CredentialStoreException {
+        // Dots in key name: #myapp?db.host
+        VaultAlias alias = VaultAlias.parse("#myapp?db.host");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("myapp", alias.getSecretPath());
+        assertEquals("db.host", alias.getKeyPath());
+    }
+
+    @Test
+    void testUrlEncodedSpace() throws CredentialStoreException {
+        // URL-encoded space: #test%20path?password
+        VaultAlias alias = VaultAlias.parse("#test%20path?password");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("test path", alias.getSecretPath());
+        assertEquals("password", alias.getKeyPath());
+    }
+
+    @Test
+    void testWithEngineType() throws CredentialStoreException {
+        // With engine type: engine=KVv1#secret?key
+        VaultAlias alias = VaultAlias.parse("engine=KVv1#secret?key");
+
+        assertNotNull(alias);
+        assertEquals("KVv1", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("secret", alias.getSecretPath());
+        assertEquals("key", alias.getKeyPath());
+    }
+
+    @Test
+    void testWithCustomMount() throws CredentialStoreException {
+        // With custom mount: @custom#secret?key
+        VaultAlias alias = VaultAlias.parse("@custom#secret?key");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("custom", alias.getMountPath());
+        assertEquals("secret", alias.getSecretPath());
+        assertEquals("key", alias.getKeyPath());
+    }
+
+    @Test
+    void testEverythingExplicit() throws CredentialStoreException {
+        // Everything explicit: engine=KVv2@team/vault#app.db.config?api.key
+        VaultAlias alias = VaultAlias.parse("engine=KVv2@team/vault#app.db.config?api.key");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("team/vault", alias.getMountPath());
+        assertEquals("app.db.config", alias.getSecretPath());
+        assertEquals("api.key", alias.getKeyPath());
+    }
+
+    @Test
+    void testMultipleUrlEncodedChars() throws CredentialStoreException {
+        // Multiple URL-encoded chars: @mount%2Fname#secret%20path?key
+        VaultAlias alias = VaultAlias.parse("@mount%2Fname#secret%20path?key");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("mount/name", alias.getMountPath());
+        assertEquals("secret path", alias.getSecretPath());
+        assertEquals("key", alias.getKeyPath());
+    }
+
+    // ========================================================================
+    // Valid Format Tests - Nested Keys
+    // ========================================================================
+
+    @Test
+    void testSimpleNestedKey() throws CredentialStoreException {
+        // Simple nested: #myapp?database/host
+        VaultAlias alias = VaultAlias.parse("#myapp?database/host");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("myapp", alias.getSecretPath());
+        assertEquals("database/host", alias.getKeyPath());
+    }
+
+    @Test
+    void testDeepNesting() throws CredentialStoreException {
+        // Deep nesting: #myapp?app/config/database/host
+        VaultAlias alias = VaultAlias.parse("#myapp?app/config/database/host");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("myapp", alias.getSecretPath());
+        assertEquals("app/config/database/host", alias.getKeyPath());
+    }
+
+    @Test
+    void testNestedWithDotsInKeys() throws CredentialStoreException {
+        // Nested with dots in keys: #services?my.app/config.key
+        VaultAlias alias = VaultAlias.parse("#services?my.app/config.key");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("services", alias.getSecretPath());
+        assertEquals("my.app/config.key", alias.getKeyPath());
+    }
+
+    @Test
+    void testComplexNestedFormat() throws CredentialStoreException {
+        // Complex: engine=KVv2@prod#app.v2?database/credentials/password
+        VaultAlias alias = VaultAlias.parse("engine=KVv2@prod#app.v2?database/credentials/password");
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("prod", alias.getMountPath());
+        assertEquals("app.v2", alias.getSecretPath());
+        assertEquals("database/credentials/password", alias.getKeyPath());
+    }
+
+    // ========================================================================
+    // URL Encoding Tests (Critical - Decode After Split)
+    // ========================================================================
+
+    @Test
+    void testUrlEncodedSpaceDecoding() throws CredentialStoreException {
+        // Test %20 (space) decoding
+        VaultAlias alias = VaultAlias.parse("#test%20path?key");
+
+        assertEquals("test path", alias.getSecretPath());
+    }
+
+    @Test
+    void testUrlEncodedHashDecoding() throws CredentialStoreException {
+        // Test %23 (#) decoding - # is encoded in secret path
+        VaultAlias alias = VaultAlias.parse("#test%23path?key");
+
+        assertEquals("test#path", alias.getSecretPath());
+    }
+
+    @Test
+    void testUrlEncodedQuestionMarkDecoding() throws CredentialStoreException {
+        // Test %3F (?) decoding - ? is encoded in secret path
+        VaultAlias alias = VaultAlias.parse("#test%3Fpath?key");
+
+        assertEquals("test?path", alias.getSecretPath());
+    }
+
+    @Test
+    void testDoubleEncodedPercent() throws CredentialStoreException {
+        // Test %2520 (encoded %) - user encoded % as %25
+        VaultAlias alias = VaultAlias.parse("#test%2520path?key");
+
+        // Should decode to "test%20path" (one level of decoding)
+        assertEquals("test%20path", alias.getSecretPath());
+    }
+
+    @Test
+    void testUrlEncodedAtSign() throws CredentialStoreException {
+        // Test %40 (@) decoding in mount path
+        VaultAlias alias = VaultAlias.parse("@mount%40name#secret?key");
+
+        assertEquals("mount@name", alias.getMountPath());
+    }
+
+    @Test
+    void testUrlEncodedSlash() throws CredentialStoreException {
+        // Test %2F (/) decoding in secret path
+        VaultAlias alias = VaultAlias.parse("#test%2Fpath?key");
+
+        assertEquals("test/path", alias.getSecretPath());
+    }
+
+    @Test
+    void testMultipleEncodedCharsInDifferentSegments() throws CredentialStoreException {
+        // Test multiple encoded chars across different segments
+        VaultAlias alias = VaultAlias.parse("@mount%20path#secret%23name?key%3Fname");
+
+        assertEquals("mount path", alias.getMountPath());
+        assertEquals("secret#name", alias.getSecretPath());
+        assertEquals("key?name", alias.getKeyPath());
+    }
+
+    // ========================================================================
+    // Invalid Format Tests
+    // ========================================================================
+
+    @Test
+    void testMissingHashBeforeSecretPath() {
+        // Missing # before secret path: secret?key
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse("secret?key"));
+
+        // Should indicate invalid format
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testMissingQuestionMarkBeforeKeyPath() {
+        // Missing ? before key path: #secret
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse("#secret"));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testMissingDelimiterAfterEngine() {
+        // Missing delimiter after engine=: engine=KVv1secret
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse("engine=KVv1secret"));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testEmptySecretPath() {
+        // Empty secret path: ?key
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse("?key"));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testEmptyKeyPath() {
+        // Empty key path: #secret?
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse("#secret?"));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testEmptySegmentInKeyPath() {
+        // Empty segment in key path: #secret?/key
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse("#secret?/key"));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testEmptySegmentInMiddleOfKeyPath() {
+        // Empty segment in middle: #secret?key//value
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse("#secret?key//value"));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testNullAlias() {
+        // Null alias
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse(null));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testEmptyAlias() {
+        // Empty alias
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse(""));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testInvalidEngineType() {
+        // Invalid engine type: engine=InvalidType#secret?key
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse("engine=InvalidType#secret?key"));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testEmptyEngineType() {
+        // Empty engine type: engine=#secret?key
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse("engine=#secret?key"));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testEmptyMountPath() {
+        // Empty mount path: @#secret?key
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parse("@#secret?key"));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    // ========================================================================
+    // Legacy Format Tests
+    // ========================================================================
+
+    @Test
+    void testSimpleLegacyFormat() throws CredentialStoreException {
+        // Simple legacy format: myapp/db.password
+        VaultAlias alias = VaultAlias.parseWithLegacySupport(
+            "myapp/db.password", "KVv2", "secret", true);
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("myapp/db", alias.getSecretPath());
+        assertEquals("password", alias.getKeyPath());
+    }
+
+    @Test
+    void testLegacyWithDotsInSecretPath() throws CredentialStoreException {
+        // Legacy with dots in secret path: app.config.key
+        VaultAlias alias = VaultAlias.parseWithLegacySupport(
+            "app.config.key", "KVv2", "secret", true);
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("app.config", alias.getSecretPath());
+        assertEquals("key", alias.getKeyPath());
+    }
+
+    @Test
+    void testLegacyWithMultipleDots() throws CredentialStoreException {
+        // Legacy with multiple dots: my.app.db.password
+        VaultAlias alias = VaultAlias.parseWithLegacySupport(
+            "my.app.db.password", "KVv2", "secret", true);
+
+        assertNotNull(alias);
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("secret", alias.getMountPath());
+        assertEquals("my.app.db", alias.getSecretPath());
+        assertEquals("password", alias.getKeyPath());
+    }
+
+    @Test
+    void testLegacyFormatNotSupportedThrowsException() {
+        // Legacy format with support disabled should throw exception
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parseWithLegacySupport(
+                "myapp/db.password", "KVv2", "secret", false));
+
+        assertNotNull(ex.getMessage());
+        // Message should include migration guidance
+    }
+
+    @Test
+    void testLegacyFormatWithoutDotThrowsException() {
+        // Invalid legacy format (no dot): myapp
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+            () -> VaultAlias.parseWithLegacySupport(
+                "myapp", "KVv2", "secret", true));
+
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testNewFormatNotTreatedAsLegacy() throws CredentialStoreException {
+        // New format should not be treated as legacy even with legacy support enabled
+        VaultAlias alias = VaultAlias.parseWithLegacySupport(
+            "#myapp?password", "KVv2", "secret", true);
+
+        assertNotNull(alias);
+        assertEquals("myapp", alias.getSecretPath());
+        assertEquals("password", alias.getKeyPath());
+    }
+
+    // ========================================================================
+    // Default Value Tests
+    // ========================================================================
+
+    @Test
+    void testCustomDefaultEngineType() throws CredentialStoreException {
+        // Test custom default engine type
+        VaultAlias alias = VaultAlias.parse("#secret?key", "KVv1", "secret");
+
+        assertEquals("KVv1", alias.getEngineType());
+    }
+
+    @Test
+    void testCustomDefaultMountPath() throws CredentialStoreException {
+        // Test custom default mount path
+        VaultAlias alias = VaultAlias.parse("#secret?key", "KVv2", "custom-mount");
+
+        assertEquals("custom-mount", alias.getMountPath());
+    }
+
+    @Test
+    void testExplicitEngineOverridesDefault() throws CredentialStoreException {
+        // Explicit engine type should override default
+        VaultAlias alias = VaultAlias.parse("engine=KVv1#secret?key", "KVv2", "secret");
+
+        assertEquals("KVv1", alias.getEngineType());
+    }
+
+    @Test
+    void testExplicitMountOverridesDefault() throws CredentialStoreException {
+        // Explicit mount path should override default
+        VaultAlias alias = VaultAlias.parse("@custom#secret?key", "KVv2", "secret");
+
+        assertEquals("custom", alias.getMountPath());
+    }
+
+    // ========================================================================
+    // Edge Cases and Special Characters
+    // ========================================================================
+
+    @Test
+    void testSecretPathWithSlashes() throws CredentialStoreException {
+        // Secret path with slashes: #team/app/database?password
+        VaultAlias alias = VaultAlias.parse("#team/app/database?password");
+
+        assertEquals("team/app/database", alias.getSecretPath());
+    }
+
+    @Test
+    void testMountPathWithSlashes() throws CredentialStoreException {
+        // Mount path with slashes: @team/backend#secret?key
+        VaultAlias alias = VaultAlias.parse("@team/backend#secret?key");
+
+        assertEquals("team/backend", alias.getMountPath());
+    }
+
+    @Test
+    void testKeyPathWithMultipleLevels() throws CredentialStoreException {
+        // Key path with multiple levels: #secret?a/b/c/d/e
+        VaultAlias alias = VaultAlias.parse("#secret?a/b/c/d/e");
+
+        assertEquals("a/b/c/d/e", alias.getKeyPath());
+    }
+
+    @Test
+    void testAllComponentsWithSpecialChars() throws CredentialStoreException {
+        // All components with special characters (URL-encoded)
+        VaultAlias alias = VaultAlias.parse(
+            "engine=KVv2@mount%20path#secret%23name?key%2Fname");
+
+        assertEquals("KVv2", alias.getEngineType());
+        assertEquals("mount path", alias.getMountPath());
+        assertEquals("secret#name", alias.getSecretPath());
+        assertEquals("key/name", alias.getKeyPath());
+    }
+
+    @Test
+    void testSingleCharacterComponents() throws CredentialStoreException {
+        // Single character components: #a?b
+        VaultAlias alias = VaultAlias.parse("#a?b");
+
+        assertEquals("a", alias.getSecretPath());
+        assertEquals("b", alias.getKeyPath());
+    }
+
+    @Test
+    void testVeryLongPaths() throws CredentialStoreException {
+        // Very long paths
+        String longSecret = "a".repeat(100);
+        String longKey = "b".repeat(100);
+        VaultAlias alias = VaultAlias.parse("#" + longSecret + "?" + longKey);
+
+        assertEquals(longSecret, alias.getSecretPath());
+        assertEquals(longKey, alias.getKeyPath());
+    }
+
+    @Test
+    void testNumericComponents() throws CredentialStoreException {
+        // Numeric components: #123/456?789
+        VaultAlias alias = VaultAlias.parse("#123/456?789");
+
+        assertEquals("123/456", alias.getSecretPath());
+        assertEquals("789", alias.getKeyPath());
+    }
+
+    @Test
+    void testUnderscoresAndHyphens() throws CredentialStoreException {
+        // Underscores and hyphens: #my_app-v2?db_host-primary
+        VaultAlias alias = VaultAlias.parse("#my_app-v2?db_host-primary");
+
+        assertEquals("my_app-v2", alias.getSecretPath());
+        assertEquals("db_host-primary", alias.getKeyPath());
+    }
+}

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultCliInteroperabilityTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultCliInteroperabilityTestCase.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.wildfly.security.hashicorp.vault.KvVersionTestHelper.cliGetSecret;
 import static org.wildfly.security.hashicorp.vault.KvVersionTestHelper.cliPutSecret;
 
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -20,6 +21,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.Container;
 import org.testcontainers.vault.VaultContainer;
+import org.wildfly.security.credential.store.CredentialStoreException;
 import org.wildfly.security.hashicorp.vault.KvVersionTestHelper.KvVersion;
 
 import io.github.jopenlibs.vault.SslConfig;
@@ -102,6 +104,53 @@ public class VaultCliInteroperabilityTestCase {
     }
 
     // =====================================================================
+    // Helper Methods for API Migration
+    // =====================================================================
+
+    /**
+     * Helper method to get a secret value using the new alias-based API.
+     */
+    private String getSecret(VaultConnector connector, String path, String key, String mountPath, KvVersion version) throws CredentialStoreException {
+        // Extract secret path from full path
+        String secretPath = path.substring(mountPath.length());
+        if (secretPath.startsWith("/")) {
+            secretPath = secretPath.substring(1);
+        }
+
+        // Build alias string
+        String aliasString = "#" + secretPath + "?" + key;
+        String engineType = version == KvVersion.V1 ? "KVv1" : "KVv2";
+
+        // Parse alias and get secret
+        VaultAlias alias = VaultAlias.parse(aliasString, engineType, mountPath);
+        Map<String, Object> data = connector.getSecretData(alias);
+        if (data == null) {
+            return null;
+        }
+
+        return KeyPathResolver.resolveKeyPath(data, key);
+    }
+
+    /**
+     * Helper method to put a secret value using the new alias-based API.
+     */
+    private void putSecret(VaultConnector connector, String path, String key, String value, String mountPath, KvVersion version) throws CredentialStoreException {
+        // Extract secret path from full path
+        String secretPath = path.substring(mountPath.length());
+        if (secretPath.startsWith("/")) {
+            secretPath = secretPath.substring(1);
+        }
+
+        // Build alias string
+        String aliasString = "#" + secretPath + "?" + key;
+        String engineType = version == KvVersion.V1 ? "KVv1" : "KVv2";
+
+        // Parse alias and put secret
+        VaultAlias alias = VaultAlias.parse(aliasString, engineType, mountPath);
+        connector.putSecretData(alias, value);
+    }
+
+    // =====================================================================
     // CLI Write → Java API Read
     // =====================================================================
 
@@ -123,8 +172,8 @@ public class VaultCliInteroperabilityTestCase {
 
         // Read using Java API
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
-        String username = connector.getSecret(mountPath + "/cli-test", "username");
-        String password = connector.getSecret(mountPath + "/cli-test", "password");
+        String username = getSecret(connector, mountPath + "/cli-test", "username", mountPath, version);
+        String password = getSecret(connector, mountPath + "/cli-test", "password", mountPath, version);
 
         assertEquals("admin", username,
             String.format("Should read CLI-written username in %s", version));
@@ -153,11 +202,11 @@ public class VaultCliInteroperabilityTestCase {
 
         // Read all keys using Java API
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
-        assertEquals("localhost", connector.getSecret(mountPath + "/app-config", "db_host"));
-        assertEquals("5432", connector.getSecret(mountPath + "/app-config", "db_port"));
-        assertEquals("myapp", connector.getSecret(mountPath + "/app-config", "db_name"));
-        assertEquals("appuser", connector.getSecret(mountPath + "/app-config", "db_user"));
-        assertEquals("apppass", connector.getSecret(mountPath + "/app-config", "db_pass"));
+        assertEquals("localhost", getSecret(connector, mountPath + "/app-config", "db_host", mountPath, version));
+        assertEquals("5432", getSecret(connector, mountPath + "/app-config", "db_port", mountPath, version));
+        assertEquals("myapp", getSecret(connector, mountPath + "/app-config", "db_name", mountPath, version));
+        assertEquals("appuser", getSecret(connector, mountPath + "/app-config", "db_user", mountPath, version));
+        assertEquals("apppass", getSecret(connector, mountPath + "/app-config", "db_pass", mountPath, version));
     }
 
     // =====================================================================
@@ -172,8 +221,8 @@ public class VaultCliInteroperabilityTestCase {
 
         // Write secret using Java API
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
-        connector.putSecret(mountPath + "/java-test", "api_key", "key123");
-        connector.putSecret(mountPath + "/java-test", "api_secret", "secret456");
+        putSecret(connector, mountPath + "/java-test", "api_key", "key123", mountPath, version);
+        putSecret(connector, mountPath + "/java-test", "api_secret", "secret456", mountPath, version);
 
         // Read using Vault CLI
         Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/java-test");
@@ -209,9 +258,9 @@ public class VaultCliInteroperabilityTestCase {
 
         // Write multi-key secret using Java API
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
-        connector.putSecret(mountPath + "/service-config", "host", "api.example.com");
-        connector.putSecret(mountPath + "/service-config", "port", "443");
-        connector.putSecret(mountPath + "/service-config", "protocol", "https");
+        putSecret(connector, mountPath + "/service-config", "host", "api.example.com", mountPath, version);
+        putSecret(connector, mountPath + "/service-config", "port", "443", mountPath, version);
+        putSecret(connector, mountPath + "/service-config", "protocol", "https", mountPath, version);
 
         // Read using CLI
         Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/service-config");
@@ -252,7 +301,7 @@ public class VaultCliInteroperabilityTestCase {
 
         // Modify using Java API
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
-        connector.putSecret(mountPath + "/modify-test", "value", "modified");
+        putSecret(connector, mountPath + "/modify-test", "value", "modified", mountPath, version);
 
         // Verify modification via CLI
         Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/modify-test");
@@ -279,7 +328,7 @@ public class VaultCliInteroperabilityTestCase {
 
         // Write initial secret using Java API
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
-        connector.putSecret(mountPath + "/modify-test2", "status", "initial");
+        putSecret(connector, mountPath + "/modify-test2", "status", "initial", mountPath, version);
 
         // Modify using CLI
         Container.ExecResult cliResult = cliPutSecret(
@@ -290,7 +339,7 @@ public class VaultCliInteroperabilityTestCase {
         assertEquals(0, cliResult.getExitCode());
 
         // Verify modification via Java API
-        String status = connector.getSecret(mountPath + "/modify-test2", "status");
+        String status = getSecret(connector, mountPath + "/modify-test2", "status", mountPath, version);
         assertEquals("updated", status,
             String.format("Java API should see CLI modification in %s", version));
     }
@@ -306,7 +355,7 @@ public class VaultCliInteroperabilityTestCase {
 
         // Modify one key using Java API
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
-        connector.putSecret(mountPath + "/multi-key", "key2", "modified");
+        putSecret(connector, mountPath + "/multi-key", "key2", "modified", mountPath, version);
 
         // Verify all keys via CLI
         Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/multi-key");
@@ -349,7 +398,7 @@ public class VaultCliInteroperabilityTestCase {
         String specialValue = "p@ssw0rd!#$%^&*(){}[]|\\:;\"'<>,.?/~`";
 
         // Write using Java API
-        connector.putSecret(mountPath + "/special-chars", "password", specialValue);
+        putSecret(connector, mountPath + "/special-chars", "password", specialValue, mountPath, version);
 
         // Read using CLI
         Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/special-chars");
@@ -368,7 +417,7 @@ public class VaultCliInteroperabilityTestCase {
             String.format("Special characters should be preserved in %s", version));
 
         // Verify round-trip via Java API
-        String retrieved = connector.getSecret(mountPath + "/special-chars", "password");
+        String retrieved = getSecret(connector, mountPath + "/special-chars", "password", mountPath, version);
         assertEquals(specialValue, retrieved,
             String.format("Special characters should round-trip correctly in %s", version));
     }
@@ -382,7 +431,7 @@ public class VaultCliInteroperabilityTestCase {
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Write empty value using Java API
-        connector.putSecret(mountPath + "/empty-test", "empty_key", "");
+        putSecret(connector, mountPath + "/empty-test", "empty_key", "", mountPath, version);
 
         // Read using CLI
         Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/empty-test");
@@ -403,5 +452,3 @@ public class VaultCliInteroperabilityTestCase {
             String.format("Empty value should be preserved in %s", version));
     }
 }
-
-// Made with Bob

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultCliInteroperabilityTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultCliInteroperabilityTestCase.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.wildfly.security.hashicorp.vault.KvVersionTestHelper.cliGetSecret;
 import static org.wildfly.security.hashicorp.vault.KvVersionTestHelper.cliPutSecret;
 
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import io.restassured.path.json.JsonPath;
@@ -81,13 +82,20 @@ public class VaultCliInteroperabilityTestCase {
         );
     }
 
-    private VaultConnector createConnector(VaultContainer<?> container, String token) throws VaultException {
+    private VaultConnector createConnector(VaultContainer<?> container, String token, KvVersion version, String mountPath) throws VaultException {
+        // Create predicate that returns true for KV v1 mounts
+        Predicate<String> kvV1Predicate = version == KvVersion.V1
+            ? path -> path.equals(mountPath) || path.startsWith(mountPath + "/")
+            : path -> false;
+
         VaultConnector connector = new VaultConnector(
             container.getHttpHostAddress(),
             token,
             "admin",
             new SslConfig().verify(true).build(),
-            true
+            true,
+            null,
+            kvV1Predicate
         );
         connector.configure();
         return connector;
@@ -114,7 +122,7 @@ public class VaultCliInteroperabilityTestCase {
             String.format("CLI write should succeed in %s: %s", version, cliResult.getStderr()));
 
         // Read using Java API
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
         String username = connector.getSecret(mountPath + "/cli-test", "username");
         String password = connector.getSecret(mountPath + "/cli-test", "password");
 
@@ -144,7 +152,7 @@ public class VaultCliInteroperabilityTestCase {
             String.format("CLI write should succeed in %s", version));
 
         // Read all keys using Java API
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
         assertEquals("localhost", connector.getSecret(mountPath + "/app-config", "db_host"));
         assertEquals("5432", connector.getSecret(mountPath + "/app-config", "db_port"));
         assertEquals("myapp", connector.getSecret(mountPath + "/app-config", "db_name"));
@@ -163,7 +171,7 @@ public class VaultCliInteroperabilityTestCase {
         vaultContainer.start();
 
         // Write secret using Java API
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
         connector.putSecret(mountPath + "/java-test", "api_key", "key123");
         connector.putSecret(mountPath + "/java-test", "api_secret", "secret456");
 
@@ -200,7 +208,7 @@ public class VaultCliInteroperabilityTestCase {
         vaultContainer.start();
 
         // Write multi-key secret using Java API
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
         connector.putSecret(mountPath + "/service-config", "host", "api.example.com");
         connector.putSecret(mountPath + "/service-config", "port", "443");
         connector.putSecret(mountPath + "/service-config", "protocol", "https");
@@ -243,7 +251,7 @@ public class VaultCliInteroperabilityTestCase {
         cliPutSecret(vaultContainer, mountPath + "/modify-test", "value=original");
 
         // Modify using Java API
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
         connector.putSecret(mountPath + "/modify-test", "value", "modified");
 
         // Verify modification via CLI
@@ -270,7 +278,7 @@ public class VaultCliInteroperabilityTestCase {
         vaultContainer.start();
 
         // Write initial secret using Java API
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
         connector.putSecret(mountPath + "/modify-test2", "status", "initial");
 
         // Modify using CLI
@@ -297,7 +305,7 @@ public class VaultCliInteroperabilityTestCase {
         cliPutSecret(vaultContainer, mountPath + "/multi-key", "key1=value1", "key2=value2", "key3=value3");
 
         // Modify one key using Java API
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
         connector.putSecret(mountPath + "/multi-key", "key2", "modified");
 
         // Verify all keys via CLI
@@ -335,7 +343,7 @@ public class VaultCliInteroperabilityTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Test various special characters
         String specialValue = "p@ssw0rd!#$%^&*(){}[]|\\:;\"'<>,.?/~`";
@@ -371,7 +379,7 @@ public class VaultCliInteroperabilityTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Write empty value using Java API
         connector.putSecret(mountPath + "/empty-test", "empty_key", "");

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultCliInteroperabilityTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultCliInteroperabilityTestCase.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wildfly.security.hashicorp.vault.KvVersionTestHelper.cliGetSecret;
+import static org.wildfly.security.hashicorp.vault.KvVersionTestHelper.cliPutSecret;
+
+import java.util.stream.Stream;
+
+import io.restassured.path.json.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.containers.Container;
+import org.testcontainers.vault.VaultContainer;
+import org.wildfly.security.hashicorp.vault.KvVersionTestHelper.KvVersion;
+
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
+
+/**
+ * Interoperability test suite validating that the Java API and Vault CLI can work together.
+ *
+ * <p>This test class verifies that:
+ * <ul>
+ *   <li>Secrets written by the Vault CLI can be read by the Java API</li>
+ *   <li>Secrets written by the Java API can be read by the Vault CLI</li>
+ *   <li>Modifications made via CLI are visible to the Java API</li>
+ *   <li>Modifications made via Java API are visible to the CLI</li>
+ *   <li>Credential format and encoding are compatible between CLI and API</li>
+ * </ul>
+ *
+ * <p><strong>Why This Matters:</strong>
+ * In real-world scenarios, users often mix CLI and API usage. For example:
+ * <ul>
+ *   <li>DevOps teams use CLI for initial setup and manual operations</li>
+ *   <li>Applications use the Java API for runtime secret access</li>
+ *   <li>CI/CD pipelines may use CLI while apps use API</li>
+ * </ul>
+ *
+ * <p>These tests ensure seamless interoperability across both KV v1 and v2.
+ */
+public class VaultCliInteroperabilityTestCase {
+
+    private VaultContainer<?> vaultContainer;
+
+    @AfterEach
+    public void cleanup() {
+        if (vaultContainer != null) {
+            vaultContainer.stop();
+        }
+    }
+
+    /**
+     * Provides test configurations for parameterized tests.
+     */
+    static Stream<Arguments> kvVersionConfigurations() {
+        return Stream.of(
+            // KV v1 only
+            Arguments.of(new VaultContainerKvV1<>("hashicorp/vault:1.13"), "secret", KvVersion.V1),
+
+            // KV v2 only
+            Arguments.of(new VaultContainer<>("hashicorp/vault:1.13")
+                .withVaultToken("myroot")
+                .withInitCommand(
+                    "secrets enable transit",
+                    "write -f transit/keys/my-key"
+                ), "secret", KvVersion.V2),
+
+            // Mixed: KV v1 at secret-v1/
+            Arguments.of(new VaultContainerKvMixed<>("hashicorp/vault:1.13"), "secret-v1", KvVersion.V1),
+
+            // Mixed: KV v2 at secret/
+            Arguments.of(new VaultContainerKvMixed<>("hashicorp/vault:1.13"), "secret", KvVersion.V2)
+        );
+    }
+
+    private VaultConnector createConnector(VaultContainer<?> container, String token) throws VaultException {
+        VaultConnector connector = new VaultConnector(
+            container.getHttpHostAddress(),
+            token,
+            "admin",
+            new SslConfig().verify(true).build(),
+            true
+        );
+        connector.configure();
+        return connector;
+    }
+
+    // =====================================================================
+    // CLI Write → Java API Read
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] Read CLI-written secret via Java API at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testReadCliWrittenSecret(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        // Write secret using Vault CLI
+        Container.ExecResult cliResult = cliPutSecret(
+            vaultContainer,
+            mountPath + "/cli-test",
+            "username=admin",
+            "password=secret123"
+        );
+        assertEquals(0, cliResult.getExitCode(),
+            String.format("CLI write should succeed in %s: %s", version, cliResult.getStderr()));
+
+        // Read using Java API
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        String username = connector.getSecret(mountPath + "/cli-test", "username");
+        String password = connector.getSecret(mountPath + "/cli-test", "password");
+
+        assertEquals("admin", username,
+            String.format("Should read CLI-written username in %s", version));
+        assertEquals("secret123", password,
+            String.format("Should read CLI-written password in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Read CLI-written multi-key secret via Java API at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testReadCliWrittenMultiKeySecret(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        // Write multi-key secret using CLI
+        Container.ExecResult cliResult = cliPutSecret(
+            vaultContainer,
+            mountPath + "/app-config",
+            "db_host=localhost",
+            "db_port=5432",
+            "db_name=myapp",
+            "db_user=appuser",
+            "db_pass=apppass"
+        );
+        assertEquals(0, cliResult.getExitCode(),
+            String.format("CLI write should succeed in %s", version));
+
+        // Read all keys using Java API
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        assertEquals("localhost", connector.getSecret(mountPath + "/app-config", "db_host"));
+        assertEquals("5432", connector.getSecret(mountPath + "/app-config", "db_port"));
+        assertEquals("myapp", connector.getSecret(mountPath + "/app-config", "db_name"));
+        assertEquals("appuser", connector.getSecret(mountPath + "/app-config", "db_user"));
+        assertEquals("apppass", connector.getSecret(mountPath + "/app-config", "db_pass"));
+    }
+
+    // =====================================================================
+    // Java API Write → CLI Read
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] Read Java-written secret via CLI at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testReadJavaWrittenSecretViaCli(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        // Write secret using Java API
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        connector.putSecret(mountPath + "/java-test", "api_key", "key123");
+        connector.putSecret(mountPath + "/java-test", "api_secret", "secret456");
+
+        // Read using Vault CLI
+        Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/java-test");
+        assertEquals(0, cliResult.getExitCode(),
+            String.format("CLI read should succeed in %s: %s", version, cliResult.getStderr()));
+
+        // Parse JSON output using RestAssured JsonPath
+        String output = cliResult.getStdout();
+        JsonPath json = JsonPath.from(output);
+
+        String apiKey, apiSecret;
+        if (version == KvVersion.V2) {
+            // KV v2 has nested structure: data.data.key
+            apiKey = json.getString("data.data.api_key");
+            apiSecret = json.getString("data.data.api_secret");
+        } else {
+            // KV v1 has flat structure: data.key
+            apiKey = json.getString("data.api_key");
+            apiSecret = json.getString("data.api_secret");
+        }
+
+        assertEquals("key123", apiKey,
+            String.format("CLI should read Java-written api_key in %s", version));
+        assertEquals("secret456", apiSecret,
+            String.format("CLI should read Java-written api_secret in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Read Java-written multi-key secret via CLI at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testReadJavaWrittenMultiKeySecretViaCli(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        // Write multi-key secret using Java API
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        connector.putSecret(mountPath + "/service-config", "host", "api.example.com");
+        connector.putSecret(mountPath + "/service-config", "port", "443");
+        connector.putSecret(mountPath + "/service-config", "protocol", "https");
+
+        // Read using CLI
+        Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/service-config");
+        assertEquals(0, cliResult.getExitCode(),
+            String.format("CLI read should succeed in %s", version));
+
+        // Parse and verify using RestAssured JsonPath
+        JsonPath json = JsonPath.from(cliResult.getStdout());
+
+        String host, port, protocol;
+        if (version == KvVersion.V2) {
+            host = json.getString("data.data.host");
+            port = json.getString("data.data.port");
+            protocol = json.getString("data.data.protocol");
+        } else {
+            host = json.getString("data.host");
+            port = json.getString("data.port");
+            protocol = json.getString("data.protocol");
+        }
+
+        assertEquals("api.example.com", host);
+        assertEquals("443", port);
+        assertEquals("https", protocol);
+    }
+
+    // =====================================================================
+    // Modification Interoperability
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] Modify CLI-written secret via Java API at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testModifyCliWrittenSecretViaJavaApi(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        // Write initial secret using CLI
+        cliPutSecret(vaultContainer, mountPath + "/modify-test", "value=original");
+
+        // Modify using Java API
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        connector.putSecret(mountPath + "/modify-test", "value", "modified");
+
+        // Verify modification via CLI
+        Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/modify-test");
+        assertEquals(0, cliResult.getExitCode());
+
+        JsonPath json = JsonPath.from(cliResult.getStdout());
+
+        String value;
+        if (version == KvVersion.V2) {
+            value = json.getString("data.data.value");
+        } else {
+            value = json.getString("data.value");
+        }
+
+        assertEquals("modified", value,
+            String.format("CLI should see Java API modification in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Modify Java-written secret via CLI at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testModifyJavaWrittenSecretViaCli(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        // Write initial secret using Java API
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        connector.putSecret(mountPath + "/modify-test2", "status", "initial");
+
+        // Modify using CLI
+        Container.ExecResult cliResult = cliPutSecret(
+            vaultContainer,
+            mountPath + "/modify-test2",
+            "status=updated"
+        );
+        assertEquals(0, cliResult.getExitCode());
+
+        // Verify modification via Java API
+        String status = connector.getSecret(mountPath + "/modify-test2", "status");
+        assertEquals("updated", status,
+            String.format("Java API should see CLI modification in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Modify single key preserves other keys (CLI→Java→CLI) at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testModifySingleKeyPreservesOthersCliJavaCli(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        // Write multi-key secret using CLI
+        cliPutSecret(vaultContainer, mountPath + "/multi-key", "key1=value1", "key2=value2", "key3=value3");
+
+        // Modify one key using Java API
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        connector.putSecret(mountPath + "/multi-key", "key2", "modified");
+
+        // Verify all keys via CLI
+        Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/multi-key");
+        assertEquals(0, cliResult.getExitCode());
+
+        JsonPath json = JsonPath.from(cliResult.getStdout());
+
+        String key1, key2, key3;
+        if (version == KvVersion.V2) {
+            key1 = json.getString("data.data.key1");
+            key2 = json.getString("data.data.key2");
+            key3 = json.getString("data.data.key3");
+        } else {
+            key1 = json.getString("data.key1");
+            key2 = json.getString("data.key2");
+            key3 = json.getString("data.key3");
+        }
+
+        assertEquals("value1", key1,
+            String.format("Unmodified key1 should be preserved in %s", version));
+        assertEquals("modified", key2,
+            String.format("Modified key2 should be updated in %s", version));
+        assertEquals("value3", key3,
+            String.format("Unmodified key3 should be preserved in %s", version));
+    }
+
+    // =====================================================================
+    // Special Characters and Encoding
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] Handle special characters in values at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testSpecialCharactersInValues(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        // Test various special characters
+        String specialValue = "p@ssw0rd!#$%^&*(){}[]|\\:;\"'<>,.?/~`";
+
+        // Write using Java API
+        connector.putSecret(mountPath + "/special-chars", "password", specialValue);
+
+        // Read using CLI
+        Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/special-chars");
+        assertEquals(0, cliResult.getExitCode());
+
+        JsonPath json = JsonPath.from(cliResult.getStdout());
+
+        String password;
+        if (version == KvVersion.V2) {
+            password = json.getString("data.data.password");
+        } else {
+            password = json.getString("data.password");
+        }
+
+        assertEquals(specialValue, password,
+            String.format("Special characters should be preserved in %s", version));
+
+        // Verify round-trip via Java API
+        String retrieved = connector.getSecret(mountPath + "/special-chars", "password");
+        assertEquals(specialValue, retrieved,
+            String.format("Special characters should round-trip correctly in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Handle empty values at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testEmptyValues(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        // Write empty value using Java API
+        connector.putSecret(mountPath + "/empty-test", "empty_key", "");
+
+        // Read using CLI
+        Container.ExecResult cliResult = cliGetSecret(vaultContainer, mountPath + "/empty-test");
+        assertEquals(0, cliResult.getExitCode());
+
+        JsonPath json = JsonPath.from(cliResult.getStdout());
+
+        String emptyKey;
+        if (version == KvVersion.V2) {
+            emptyKey = json.getString("data.data.empty_key");
+        } else {
+            emptyKey = json.getString("data.empty_key");
+        }
+
+        assertNotNull(emptyKey,
+            String.format("Empty key should exist in %s", version));
+        assertEquals("", emptyKey,
+            String.format("Empty value should be preserved in %s", version));
+    }
+}
+
+// Made with Bob

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultCliInteroperabilityTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultCliInteroperabilityTestCase.java
@@ -11,7 +11,6 @@ import static org.wildfly.security.hashicorp.vault.KvVersionTestHelper.cliGetSec
 import static org.wildfly.security.hashicorp.vault.KvVersionTestHelper.cliPutSecret;
 
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import io.restassured.path.json.JsonPath;
@@ -85,19 +84,12 @@ public class VaultCliInteroperabilityTestCase {
     }
 
     private VaultConnector createConnector(VaultContainer<?> container, String token, KvVersion version, String mountPath) throws VaultException {
-        // Create predicate that returns true for KV v1 mounts
-        Predicate<String> kvV1Predicate = version == KvVersion.V1
-            ? path -> path.equals(mountPath) || path.startsWith(mountPath + "/")
-            : path -> false;
-
         VaultConnector connector = new VaultConnector(
             container.getHttpHostAddress(),
             token,
             "admin",
             new SslConfig().verify(true).build(),
-            true,
-            null,
-            kvV1Predicate
+            true
         );
         connector.configure();
         return connector;

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
@@ -117,9 +117,10 @@ public class VaultConnectorHttpsTestCase {
                 );
         vaultTestContainer.start();
 
-        // Test vault service with incorrect token - this should throw VaultException during configure()
+        // Test vault service with incorrect token - this should throw VaultException when attempting to use it
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "incorrect-token", "admin", httpsSslConfig, true);
-        assertThrows(VaultException.class, vaultService::configure,
+        vaultService.configure();
+        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"),
                 "VaultException should be thrown due to authentication failure");
     }
 
@@ -160,7 +161,8 @@ public class VaultConnectorHttpsTestCase {
 
             VaultConnector vaultService = new VaultConnector(
                     vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", wrongTrustConfig, true);
-            assertThrows(VaultException.class, vaultService::configure);
+            vaultService.configure();
+            assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"));
         } finally {
             VaultTestUtils.cleanupDir(wrongCertDir);
         }
@@ -177,6 +179,7 @@ public class VaultConnectorHttpsTestCase {
         SslConfig noTrustConfig = new SslConfig().verify(true).build();
         VaultConnector vaultService = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", noTrustConfig, true);
-        assertThrows(VaultException.class, vaultService::configure);
+        vaultService.configure();
+        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"));
     }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
@@ -4,25 +4,25 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.VaultException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-
-import io.smallrye.certs.CertificateFiles;
-import io.smallrye.certs.CertificateGenerator;
-import io.smallrye.certs.CertificateRequest;
-import io.smallrye.certs.Format;
-import io.smallrye.certs.PemCertificateFiles;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
+import io.smallrye.certs.CertificateFiles;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.PemCertificateFiles;
 
 /**
  * Dedicated tests for Vault listening on HTTPS interface

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
@@ -100,8 +100,8 @@ public class VaultConnectorHttpsTestCase {
         // setup test container with vault
         startVaultTestContainer();
 
-        // Test vault service
-        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", httpsSslConfig, true);
+        // Test vault service - namespace is null for default namespace
+        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", null, httpsSslConfig, true);
         vaultService.configure();
         assertEquals("password123", getSecret(vaultService, "secret/testing1", "top_secret"));
     }
@@ -111,8 +111,8 @@ public class VaultConnectorHttpsTestCase {
         // setup test container with vault
         startVaultTestContainer();
 
-        // Test vault service
-        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", httpsSslConfig, true);
+        // Test vault service - namespace is null for default namespace
+        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", null, httpsSslConfig, true);
         vaultService.configure();
         putSecret(vaultService, "secret/testing1", "top_secret2", "password2");
 
@@ -124,8 +124,8 @@ public class VaultConnectorHttpsTestCase {
         // setup test container with vault
         startVaultTestContainer();
 
-        // Test vault service
-        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", httpsSslConfig, true);
+        // Test vault service - namespace is null for default namespace
+        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", null, httpsSslConfig, true);
         vaultService.configure();
 
         // First verify the secret exists
@@ -165,8 +165,8 @@ public class VaultConnectorHttpsTestCase {
         // setup and start test container with vault
         startVaultTestContainer();
 
-        // Test vault service
-        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", "admin", httpsSslConfig, true);
+        // Test vault service - namespace is null for default namespace
+        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", null, httpsSslConfig, true);
         vaultService.configure();
         removeSecret(vaultService, "secret/testing1", "top_secret");
     }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
@@ -12,9 +12,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.wildfly.security.credential.store.CredentialStoreException;
 
 import io.github.jopenlibs.vault.SslConfig;
 import io.github.jopenlibs.vault.VaultException;
@@ -59,6 +61,40 @@ public class VaultConnectorHttpsTestCase {
                 .build();
     }
 
+    /**
+     * Helper method to get a secret value using the new alias-based API.
+     */
+    private String getSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        Map<String, Object> data = connector.getSecretData(alias);
+        if (data == null) {
+            return null;
+        }
+        return KeyPathResolver.resolveKeyPath(data, key);
+    }
+
+    /**
+     * Helper method to put a secret value using the new alias-based API.
+     */
+    private void putSecret(VaultConnector connector, String path, String key, String value) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        connector.putSecretData(alias, value);
+    }
+
+    /**
+     * Helper method to remove a secret value using the new alias-based API.
+     */
+    private void removeSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        connector.removeSecretData(alias);
+    }
+
     @Test
     public void testGetSecretFromVaultService() throws Exception {
         // setup test container with vault
@@ -67,7 +103,7 @@ public class VaultConnectorHttpsTestCase {
         // Test vault service
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", httpsSslConfig, true);
         vaultService.configure();
-        assertEquals("password123", vaultService.getSecret("secret/testing1", "top_secret"));
+        assertEquals("password123", getSecret(vaultService, "secret/testing1", "top_secret"));
     }
 
     @Test
@@ -78,9 +114,9 @@ public class VaultConnectorHttpsTestCase {
         // Test vault service
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", httpsSslConfig, true);
         vaultService.configure();
-        vaultService.putSecret("secret/testing1", "top_secret2", "password2");
+        putSecret(vaultService, "secret/testing1", "top_secret2", "password2");
 
-        assertEquals("password2", vaultService.getSecret("secret/testing1", "top_secret2"));
+        assertEquals("password2", getSecret(vaultService, "secret/testing1", "top_secret2"));
     }
 
     @Test
@@ -93,13 +129,13 @@ public class VaultConnectorHttpsTestCase {
         vaultService.configure();
 
         // First verify the secret exists
-        String originalSecret = vaultService.getSecret("secret/testing1", "top_secret");
+        String originalSecret = getSecret(vaultService, "secret/testing1", "top_secret");
         assertEquals("password123", originalSecret);
 
         // Remove the secret
-        vaultService.removeSecret("secret/testing1", "top_secret");
+        removeSecret(vaultService, "secret/testing1", "top_secret");
 
-        assertNull(vaultService.getSecret("secret/testing1", "top_secret"));
+        assertNull(getSecret(vaultService, "secret/testing1", "top_secret"));
         // If we get here, the test should fail because exception was expected
 
     }
@@ -117,11 +153,11 @@ public class VaultConnectorHttpsTestCase {
                 );
         vaultTestContainer.start();
 
-        // Test vault service with incorrect token - this should throw VaultException when attempting to use it
+        // Test vault service with incorrect token - this should throw CredentialStoreException when attempting to use it
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "incorrect-token", "admin", httpsSslConfig, true);
         vaultService.configure();
-        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"),
-                "VaultException should be thrown due to authentication failure");
+        assertThrows(CredentialStoreException.class, () -> getSecret(vaultService, "secret/testing1", "top_secret"),
+                "CredentialStoreException should be thrown due to authentication failure");
     }
 
     @Test
@@ -132,7 +168,7 @@ public class VaultConnectorHttpsTestCase {
         // Test vault service
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "myroot", "admin", httpsSslConfig, true);
         vaultService.configure();
-        vaultService.removeSecret("secret/testing1", "top_secret");
+        removeSecret(vaultService, "secret/testing1", "top_secret");
     }
 
     /**
@@ -162,7 +198,7 @@ public class VaultConnectorHttpsTestCase {
             VaultConnector vaultService = new VaultConnector(
                     vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", wrongTrustConfig, true);
             vaultService.configure();
-            assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"));
+            assertThrows(CredentialStoreException.class, () -> getSecret(vaultService, "secret/testing1", "top_secret"));
         } finally {
             VaultTestUtils.cleanupDir(wrongCertDir);
         }
@@ -180,6 +216,6 @@ public class VaultConnectorHttpsTestCase {
         VaultConnector vaultService = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(), "myroot", "secret/testing1", noTrustConfig, true);
         vaultService.configure();
-        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"));
+        assertThrows(CredentialStoreException.class, () -> getSecret(vaultService, "secret/testing1", "top_secret"));
     }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorJwtAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorJwtAuthTestCase.java
@@ -13,12 +13,14 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.Map;
 
 import org.jose4j.lang.JoseException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.wildfly.security.credential.store.CredentialStoreException;
 import org.wildfly.security.hashicorp.vault.auth.JwtAuthConfig;
 import org.wildfly.security.hashicorp.vault.auth.JwtGenerator;
 
@@ -97,14 +99,38 @@ public class VaultConnectorJwtAuthTestCase {
     }
 
     /**
+     * Helper method to get a secret value using the new alias-based API.
+     */
+    private String getSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        Map<String, Object> data = connector.getSecretData(alias);
+        if (data == null) {
+            return null;
+        }
+        return KeyPathResolver.resolveKeyPath(data, key);
+    }
+
+    /**
+     * Helper method to remove a secret value using the new alias-based API.
+     */
+    private void removeSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        connector.removeSecretData(alias);
+    }
+
+    /**
      * Configure vault connector with proper HTTPS config and try to log in using valid JWT
      * Test will succeed wince everything is configured properly
      */
     @Test
-    public void testGetSecretFromVaultService() throws VaultException {
+    public void testGetSecretFromVaultService() throws Exception {
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), validJwtConfig, "secret/testing1", permissibleSslAuthConfig);
         vaultService.configure();
-        assertEquals("password123", vaultService.getSecret("secret/testing1", "top_secret"));
+        assertEquals("password123", getSecret(vaultService, "secret/testing1", "top_secret"));
     }
 
     /**
@@ -115,7 +141,7 @@ public class VaultConnectorJwtAuthTestCase {
     public void testGetSecretFromVaultServiceInvalidJwtToken() throws Exception {
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), new JwtConfig("someInvalidToken", ROLE_NAME, "jwt"), "secret/testing1", permissibleSslAuthConfig);
         vaultService.configure();
-        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"),
+        assertThrows(CredentialStoreException.class, () -> getSecret(vaultService, "secret/testing1", "top_secret"),
                 "Correct SSL HTTPS config was provided but JWT was invalid. This should fail.");
     }
 
@@ -125,16 +151,16 @@ public class VaultConnectorJwtAuthTestCase {
      * Test will succeed when the secret is obtained removed and obtained again.
      */
     @Test
-    public void testRemoveSecretFromVaultService() throws VaultException {
+    public void testRemoveSecretFromVaultService() throws Exception {
         final VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), validJwtConfig, "secret/testing1", permissibleSslAuthConfig);
         vaultService.configure();
 
-        final String originalSecret = vaultService.getSecret("secret/testing1", "top_secret");
+        final String originalSecret = getSecret(vaultService, "secret/testing1", "top_secret");
         assertEquals("password123", originalSecret);
 
-        vaultService.removeSecret("secret/testing1", "top_secret");
+        removeSecret(vaultService, "secret/testing1", "top_secret");
 
-        assertNull(vaultService.getSecret("secret/testing1", "top_secret"));
+        assertNull(getSecret(vaultService, "secret/testing1", "top_secret"));
     }
 
     private static String keyToPem(String header, byte[] encoded) {

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorJwtAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorJwtAuthTestCase.java
@@ -128,7 +128,7 @@ public class VaultConnectorJwtAuthTestCase {
      */
     @Test
     public void testGetSecretFromVaultService() throws Exception {
-        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), validJwtConfig, "secret/testing1", permissibleSslAuthConfig);
+        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), validJwtConfig, null, permissibleSslAuthConfig);
         vaultService.configure();
         assertEquals("password123", getSecret(vaultService, "secret/testing1", "top_secret"));
     }
@@ -139,7 +139,7 @@ public class VaultConnectorJwtAuthTestCase {
      */
     @Test
     public void testGetSecretFromVaultServiceInvalidJwtToken() throws Exception {
-        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), new JwtConfig("someInvalidToken", ROLE_NAME, "jwt"), "secret/testing1", permissibleSslAuthConfig);
+        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), new JwtConfig("someInvalidToken", ROLE_NAME, "jwt"), null, permissibleSslAuthConfig);
         vaultService.configure();
         assertThrows(CredentialStoreException.class, () -> getSecret(vaultService, "secret/testing1", "top_secret"),
                 "Correct SSL HTTPS config was provided but JWT was invalid. This should fail.");
@@ -152,7 +152,7 @@ public class VaultConnectorJwtAuthTestCase {
      */
     @Test
     public void testRemoveSecretFromVaultService() throws Exception {
-        final VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), validJwtConfig, "secret/testing1", permissibleSslAuthConfig);
+        final VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), validJwtConfig, null, permissibleSslAuthConfig);
         vaultService.configure();
 
         final String originalSecret = getSecret(vaultService, "secret/testing1", "top_secret");

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorJwtAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorJwtAuthTestCase.java
@@ -4,8 +4,16 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.VaultException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
 import org.jose4j.lang.JoseException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -14,15 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.wildfly.security.hashicorp.vault.auth.JwtAuthConfig;
 import org.wildfly.security.hashicorp.vault.auth.JwtGenerator;
 
-import java.io.IOException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
 
 /**
  * Set of tests verifying functionality of VaultConnector when using TLS certificate authentication method

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorJwtAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorJwtAuthTestCase.java
@@ -112,9 +112,10 @@ public class VaultConnectorJwtAuthTestCase {
      * Test will fail since the connector will try to use the JWT to authenticate.
      */
     @Test
-    public void testGetSecretFromVaultServiceInvalidJwtToken() {
+    public void testGetSecretFromVaultServiceInvalidJwtToken() throws Exception {
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), new JwtConfig("someInvalidToken", ROLE_NAME, "jwt"), "secret/testing1", permissibleSslAuthConfig);
-        assertThrows(VaultException.class, vaultService::configure,
+        vaultService.configure();
+        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"),
                 "Correct SSL HTTPS config was provided but JWT was invalid. This should fail.");
     }
 

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorKvVersionTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorKvVersionTestCase.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -18,7 +19,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.vault.VaultContainer;
+import org.wildfly.security.auth.server.IdentityCredentials;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.store.CredentialStoreException;
 import org.wildfly.security.hashicorp.vault.KvVersionTestHelper.KvVersion;
+import org.wildfly.security.password.interfaces.ClearPassword;
 
 import io.github.jopenlibs.vault.SslConfig;
 import io.github.jopenlibs.vault.VaultException;
@@ -108,6 +113,78 @@ public class VaultConnectorKvVersionTestCase {
     }
 
     // =====================================================================
+    // Helper Methods for API Migration
+    // =====================================================================
+
+    /**
+     * Helper method to get a secret value using the new alias-based API.
+     * Converts old-style path/key calls to new VaultAlias format.
+     */
+    private String getSecret(VaultConnector connector, String path, String key, String mountPath, KvVersion version) throws CredentialStoreException {
+        // Extract secret path from full path (remove mount prefix)
+        String secretPath = path.substring(mountPath.length());
+        if (secretPath.startsWith("/")) {
+            secretPath = secretPath.substring(1);
+        }
+
+        // Build alias string: #secret-path?key
+        String aliasString = "#" + secretPath + "?" + key;
+
+        // Determine engine type from KV version
+        String engineType = version == KvVersion.V1 ? "KVv1" : "KVv2";
+
+        // Parse alias
+        VaultAlias alias = VaultAlias.parse(aliasString, engineType, mountPath);
+
+        // Get secret data
+        Map<String, Object> data = connector.getSecretData(alias);
+        if (data == null) {
+            return null;
+        }
+
+        // Resolve key path
+        return KeyPathResolver.resolveKeyPath(data, key);
+    }
+
+    /**
+     * Helper method to put a secret value using the new alias-based API.
+     */
+    private void putSecret(VaultConnector connector, String path, String key, String value, String mountPath, KvVersion version) throws CredentialStoreException {
+        // Extract secret path from full path
+        String secretPath = path.substring(mountPath.length());
+        if (secretPath.startsWith("/")) {
+            secretPath = secretPath.substring(1);
+        }
+
+        // Build alias string
+        String aliasString = "#" + secretPath + "?" + key;
+        String engineType = version == KvVersion.V1 ? "KVv1" : "KVv2";
+
+        // Parse alias and put secret
+        VaultAlias alias = VaultAlias.parse(aliasString, engineType, mountPath);
+        connector.putSecretData(alias, value);
+    }
+
+    /**
+     * Helper method to remove a secret key using the new alias-based API.
+     */
+    private void removeSecret(VaultConnector connector, String path, String key, String mountPath, KvVersion version) throws CredentialStoreException {
+        // Extract secret path from full path
+        String secretPath = path.substring(mountPath.length());
+        if (secretPath.startsWith("/")) {
+            secretPath = secretPath.substring(1);
+        }
+
+        // Build alias string
+        String aliasString = "#" + secretPath + "?" + key;
+        String engineType = version == KvVersion.V1 ? "KVv1" : "KVv2";
+
+        // Parse alias and remove secret
+        VaultAlias alias = VaultAlias.parse(aliasString, engineType, mountPath);
+        connector.removeSecretData(alias);
+    }
+
+    // =====================================================================
     // Basic CRUD Operations
     // =====================================================================
 
@@ -118,7 +195,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer.start();
 
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
-        String secret = connector.getSecret(mountPath + "/testing1", "top_secret");
+        String secret = getSecret(connector, mountPath + "/testing1", "top_secret", mountPath, version);
 
         assertEquals("password123", secret,
             String.format("Should retrieve secret from %s mount", version));
@@ -133,10 +210,10 @@ public class VaultConnectorKvVersionTestCase {
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Put a new secret
-        connector.putSecret(mountPath + "/testing1", "new_secret", "newvalue123");
+        putSecret(connector, mountPath + "/testing1", "new_secret", "newvalue123", mountPath, version);
 
         // Verify it was stored
-        String retrieved = connector.getSecret(mountPath + "/testing1", "new_secret");
+        String retrieved = getSecret(connector, mountPath + "/testing1", "new_secret", mountPath, version);
         assertEquals("newvalue123", retrieved,
             String.format("Should store and retrieve new secret in %s", version));
     }
@@ -150,14 +227,14 @@ public class VaultConnectorKvVersionTestCase {
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Verify original value
-        String original = connector.getSecret(mountPath + "/testing1", "top_secret");
+        String original = getSecret(connector, mountPath + "/testing1", "top_secret", mountPath, version);
         assertEquals("password123", original);
 
         // Update the secret
-        connector.putSecret(mountPath + "/testing1", "top_secret", "updated_password");
+        putSecret(connector, mountPath + "/testing1", "top_secret", "updated_password", mountPath, version);
 
         // Verify updated value
-        String updated = connector.getSecret(mountPath + "/testing1", "top_secret");
+        String updated = getSecret(connector, mountPath + "/testing1", "top_secret", mountPath, version);
         assertEquals("updated_password", updated,
             String.format("Should update existing secret in %s", version));
     }
@@ -171,14 +248,14 @@ public class VaultConnectorKvVersionTestCase {
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Verify secret exists
-        String original = connector.getSecret(mountPath + "/testing1", "top_secret");
+        String original = getSecret(connector, mountPath + "/testing1", "top_secret", mountPath, version);
         assertNotNull(original);
 
         // Remove the secret
-        connector.removeSecret(mountPath + "/testing1", "top_secret");
+        removeSecret(connector, mountPath + "/testing1", "top_secret", mountPath, version);
 
         // Verify it's gone
-        String removed = connector.getSecret(mountPath + "/testing1", "top_secret");
+        String removed = getSecret(connector, mountPath + "/testing1", "top_secret", mountPath, version);
         assertNull(removed,
             String.format("Should remove secret from %s", version));
     }
@@ -196,16 +273,16 @@ public class VaultConnectorKvVersionTestCase {
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Verify both keys exist initially
-        assertEquals("secretpass", connector.getSecret(mountPath + "/testing2", "dbuser"));
-        assertEquals("jmspass", connector.getSecret(mountPath + "/testing2", "jmsuser"));
+        assertEquals("secretpass", getSecret(connector, mountPath + "/testing2", "dbuser", mountPath, version));
+        assertEquals("jmspass", getSecret(connector, mountPath + "/testing2", "jmsuser", mountPath, version));
 
         // Modify only dbuser
-        connector.putSecret(mountPath + "/testing2", "dbuser", "new_dbpass");
+        putSecret(connector, mountPath + "/testing2", "dbuser", "new_dbpass", mountPath, version);
 
         // Verify dbuser changed but jmsuser remained
-        assertEquals("new_dbpass", connector.getSecret(mountPath + "/testing2", "dbuser"),
+        assertEquals("new_dbpass", getSecret(connector, mountPath + "/testing2", "dbuser", mountPath, version),
             String.format("Should update modified key in %s", version));
-        assertEquals("jmspass", connector.getSecret(mountPath + "/testing2", "jmsuser"),
+        assertEquals("jmspass", getSecret(connector, mountPath + "/testing2", "jmsuser", mountPath, version),
             String.format("Should preserve unmodified key in %s", version));
     }
 
@@ -218,16 +295,16 @@ public class VaultConnectorKvVersionTestCase {
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Verify both keys exist
-        assertNotNull(connector.getSecret(mountPath + "/testing2", "dbuser"));
-        assertNotNull(connector.getSecret(mountPath + "/testing2", "jmsuser"));
+        assertNotNull(getSecret(connector, mountPath + "/testing2", "dbuser", mountPath, version));
+        assertNotNull(getSecret(connector, mountPath + "/testing2", "jmsuser", mountPath, version));
 
         // Remove only dbuser
-        connector.removeSecret(mountPath + "/testing2", "dbuser");
+        removeSecret(connector, mountPath + "/testing2", "dbuser", mountPath, version);
 
         // Verify dbuser is gone but jmsuser remains
-        assertNull(connector.getSecret(mountPath + "/testing2", "dbuser"),
+        assertNull(getSecret(connector, mountPath + "/testing2", "dbuser", mountPath, version),
             String.format("Should remove specified key in %s", version));
-        assertNotNull(connector.getSecret(mountPath + "/testing2", "jmsuser"),
+        assertNotNull(getSecret(connector, mountPath + "/testing2", "jmsuser", mountPath, version),
             String.format("Should preserve other keys in %s", version));
     }
 
@@ -243,7 +320,7 @@ public class VaultConnectorKvVersionTestCase {
 
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
-        String result = connector.getSecret(mountPath + "/nonexistent", "somekey");
+        String result = getSecret(connector, mountPath + "/nonexistent", "somekey", mountPath, version);
         assertNull(result,
             String.format("Should return null for non-existent path in %s", version));
     }
@@ -256,7 +333,7 @@ public class VaultConnectorKvVersionTestCase {
 
         VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
-        String result = connector.getSecret(mountPath + "/testing1", "nonexistent_key");
+        String result = getSecret(connector, mountPath + "/testing1", "nonexistent_key", mountPath, version);
         assertNull(result,
             String.format("Should return null for non-existent key in %s", version));
     }
@@ -279,44 +356,8 @@ public class VaultConnectorKvVersionTestCase {
         connector.configure();
 
         // Try to use the connector - this should trigger lazy initialization and fail
-        assertThrows(VaultException.class, () -> connector.getSecret(mountPath + "/test", "key"),
+        assertThrows(Exception.class, () -> getSecret(connector, mountPath + "/test", "key", mountPath, version),
             String.format("Should throw VaultException for invalid token in %s", version));
-    }
-
-    // =====================================================================
-    // List Operations
-    // =====================================================================
-
-    @ParameterizedTest(name = "[{2}] List keys at path {1}")
-    @MethodSource("kvVersionConfigurations")
-    public void testGetKeysForPath(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
-        vaultContainer = container;
-        vaultContainer.start();
-
-        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
-
-        var keys = connector.getKeysForPath(mountPath + "/testing2");
-        assertNotNull(keys, String.format("Should return keys for path in %s", version));
-        assertTrue(keys.contains("dbuser"),
-            String.format("Should contain 'dbuser' key in %s", version));
-        assertTrue(keys.contains("jmsuser"),
-            String.format("Should contain 'jmsuser' key in %s", version));
-    }
-
-    @ParameterizedTest(name = "[{2}] List non-existent path throws exception at {1}")
-    @MethodSource("kvVersionConfigurations")
-    public void testGetKeysForNonExistentPath(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
-        vaultContainer = container;
-        vaultContainer.start();
-
-        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
-
-        VaultException ex = assertThrows(VaultException.class,
-            () -> connector.getKeysForPath(mountPath + "/nonexistent"),
-            String.format("Should throw exception for non-existent path in %s", version));
-
-        assertTrue(ex.getMessage().contains("Path does not exist"),
-            String.format("Exception should mention path doesn't exist in %s", version));
     }
 
     // =====================================================================
@@ -333,15 +374,13 @@ public class VaultConnectorKvVersionTestCase {
 
         // Create secret at nested path
         String nestedPath = mountPath + "/app/database/credentials";
-        connector.putSecret(nestedPath, "username", "dbuser");
-        connector.putSecret(nestedPath, "password", "dbpass");
+        putSecret(connector, nestedPath, "username", "dbuser", mountPath, version);
+        putSecret(connector, nestedPath, "password", "dbpass", mountPath, version);
 
         // Retrieve from nested path
-        assertEquals("dbuser", connector.getSecret(nestedPath, "username"),
+        assertEquals("dbuser", getSecret(connector, nestedPath, "username", mountPath, version),
             String.format("Should handle nested paths in %s", version));
-        assertEquals("dbpass", connector.getSecret(nestedPath, "password"),
+        assertEquals("dbpass", getSecret(connector, nestedPath, "password", mountPath, version),
             String.format("Should handle nested paths in %s", version));
     }
 }
-
-// Made with Bob

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorKvVersionTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorKvVersionTestCase.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.vault.VaultContainer;
+import org.wildfly.security.hashicorp.vault.KvVersionTestHelper.KvTestConfig;
+import org.wildfly.security.hashicorp.vault.KvVersionTestHelper.KvVersion;
+
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
+
+/**
+ * Parameterized test suite for {@link VaultConnector} covering both KV v1 and KV v2 engines.
+ *
+ * <p>This test class uses JUnit 5's {@code @ParameterizedTest} to run the same test logic
+ * against different Vault configurations:
+ * <ul>
+ *   <li>KV v1 only</li>
+ *   <li>KV v2 only (default)</li>
+ *   <li>Mixed environment (both v1 and v2 at different mounts)</li>
+ * </ul>
+ *
+ * <p><strong>Test Coverage:</strong>
+ * <ul>
+ *   <li>Basic CRUD operations (Create, Read, Update, Delete)</li>
+ *   <li>Path format validation</li>
+ *   <li>Error handling (404, 403)</li>
+ *   <li>Multi-key secret operations</li>
+ *   <li>List operations</li>
+ * </ul>
+ *
+ * <p><strong>Key Differences Tested:</strong>
+ * <ul>
+ *   <li><strong>KV v1:</strong> Direct paths, no versioning, full overwrite on update</li>
+ *   <li><strong>KV v2:</strong> /data/ paths, versioning, creates new version on update</li>
+ * </ul>
+ */
+public class VaultConnectorKvVersionTestCase {
+
+    private VaultContainer<?> vaultContainer;
+
+    @AfterEach
+    public void cleanup() {
+        if (vaultContainer != null) {
+            vaultContainer.stop();
+        }
+    }
+
+    /**
+     * Provides test configurations for parameterized tests.
+     * Each configuration includes a Vault container with a specific KV version setup.
+     */
+    static Stream<Arguments> kvVersionConfigurations() {
+        return Stream.of(
+            // KV v1 only
+            Arguments.of(new VaultContainerKvV1<>("hashicorp/vault:1.13"), "secret", KvVersion.V1),
+
+            // KV v2 only (using standard VaultContainer which defaults to v2)
+            Arguments.of(new VaultContainer<>("hashicorp/vault:1.13")
+                .withVaultToken("myroot")
+                .withInitCommand(
+                    "secrets enable transit",
+                    "write -f transit/keys/my-key",
+                    "kv put secret/testing1 top_secret=password123",
+                    "kv put secret/testing2 dbuser=secretpass jmsuser=jmspass",
+                    "kv put secret/my-secret my-value=s3cr3t"
+                ), "secret", KvVersion.V2),
+
+            // Mixed: KV v1 at secret-v1/
+            Arguments.of(new VaultContainerKvMixed<>("hashicorp/vault:1.13"), "secret-v1", KvVersion.V1),
+
+            // Mixed: KV v2 at secret/
+            Arguments.of(new VaultContainerKvMixed<>("hashicorp/vault:1.13"), "secret", KvVersion.V2)
+        );
+    }
+
+    private VaultConnector createConnector(VaultContainer<?> container, String token) throws VaultException {
+        VaultConnector connector = new VaultConnector(
+            container.getHttpHostAddress(),
+            token,
+            "admin",
+            new SslConfig().verify(true).build(),
+            true
+        );
+        connector.configure();
+        return connector;
+    }
+
+    // =====================================================================
+    // Basic CRUD Operations
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] Get secret from {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetSecret(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        String secret = connector.getSecret(mountPath + "/testing1", "top_secret");
+
+        assertEquals("password123", secret,
+            String.format("Should retrieve secret from %s mount", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Put secret to {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testPutSecret(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        // Put a new secret
+        connector.putSecret(mountPath + "/testing1", "new_secret", "newvalue123");
+
+        // Verify it was stored
+        String retrieved = connector.getSecret(mountPath + "/testing1", "new_secret");
+        assertEquals("newvalue123", retrieved,
+            String.format("Should store and retrieve new secret in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Update existing secret in {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testUpdateSecret(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        // Verify original value
+        String original = connector.getSecret(mountPath + "/testing1", "top_secret");
+        assertEquals("password123", original);
+
+        // Update the secret
+        connector.putSecret(mountPath + "/testing1", "top_secret", "updated_password");
+
+        // Verify updated value
+        String updated = connector.getSecret(mountPath + "/testing1", "top_secret");
+        assertEquals("updated_password", updated,
+            String.format("Should update existing secret in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Remove secret from {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testRemoveSecret(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        // Verify secret exists
+        String original = connector.getSecret(mountPath + "/testing1", "top_secret");
+        assertNotNull(original);
+
+        // Remove the secret
+        connector.removeSecret(mountPath + "/testing1", "top_secret");
+
+        // Verify it's gone
+        String removed = connector.getSecret(mountPath + "/testing1", "top_secret");
+        assertNull(removed,
+            String.format("Should remove secret from %s", version));
+    }
+
+    // =====================================================================
+    // Multi-Key Secret Operations
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] Modify single key in multi-key secret at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testModifySingleKeyInMultiKeySecret(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        // Verify both keys exist initially
+        assertEquals("secretpass", connector.getSecret(mountPath + "/testing2", "dbuser"));
+        assertEquals("jmspass", connector.getSecret(mountPath + "/testing2", "jmsuser"));
+
+        // Modify only dbuser
+        connector.putSecret(mountPath + "/testing2", "dbuser", "new_dbpass");
+
+        // Verify dbuser changed but jmsuser remained
+        assertEquals("new_dbpass", connector.getSecret(mountPath + "/testing2", "dbuser"),
+            String.format("Should update modified key in %s", version));
+        assertEquals("jmspass", connector.getSecret(mountPath + "/testing2", "jmsuser"),
+            String.format("Should preserve unmodified key in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Remove single key from multi-key secret at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testRemoveSingleKeyFromMultiKeySecret(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        // Verify both keys exist
+        assertNotNull(connector.getSecret(mountPath + "/testing2", "dbuser"));
+        assertNotNull(connector.getSecret(mountPath + "/testing2", "jmsuser"));
+
+        // Remove only dbuser
+        connector.removeSecret(mountPath + "/testing2", "dbuser");
+
+        // Verify dbuser is gone but jmsuser remains
+        assertNull(connector.getSecret(mountPath + "/testing2", "dbuser"),
+            String.format("Should remove specified key in %s", version));
+        assertNotNull(connector.getSecret(mountPath + "/testing2", "jmsuser"),
+            String.format("Should preserve other keys in %s", version));
+    }
+
+    // =====================================================================
+    // Error Handling
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] Get non-existent secret returns null at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetNonExistentSecretReturnsNull(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        String result = connector.getSecret(mountPath + "/nonexistent", "somekey");
+        assertNull(result,
+            String.format("Should return null for non-existent path in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Get non-existent key returns null at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetNonExistentKeyReturnsNull(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        String result = connector.getSecret(mountPath + "/testing1", "nonexistent_key");
+        assertNull(result,
+            String.format("Should return null for non-existent key in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] Invalid token throws exception at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testInvalidTokenThrowsException(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = new VaultConnector(
+            vaultContainer.getHttpHostAddress(),
+            "invalid-token",
+            "admin",
+            new SslConfig().verify(true).build(),
+            true
+        );
+
+        assertThrows(VaultException.class, connector::configure,
+            String.format("Should throw VaultException for invalid token in %s", version));
+    }
+
+    // =====================================================================
+    // List Operations
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] List keys at path {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetKeysForPath(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        var keys = connector.getKeysForPath(mountPath + "/testing2");
+        assertNotNull(keys, String.format("Should return keys for path in %s", version));
+        assertTrue(keys.contains("dbuser"),
+            String.format("Should contain 'dbuser' key in %s", version));
+        assertTrue(keys.contains("jmsuser"),
+            String.format("Should contain 'jmsuser' key in %s", version));
+    }
+
+    @ParameterizedTest(name = "[{2}] List non-existent path throws exception at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testGetKeysForNonExistentPath(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        VaultException ex = assertThrows(VaultException.class,
+            () -> connector.getKeysForPath(mountPath + "/nonexistent"),
+            String.format("Should throw exception for non-existent path in %s", version));
+
+        assertTrue(ex.getMessage().contains("Path does not exist"),
+            String.format("Exception should mention path doesn't exist in %s", version));
+    }
+
+    // =====================================================================
+    // Path Format Validation
+    // =====================================================================
+
+    @ParameterizedTest(name = "[{2}] Nested path operations at {1}")
+    @MethodSource("kvVersionConfigurations")
+    public void testNestedPathOperations(VaultContainer<?> container, String mountPath, KvVersion version) throws Exception {
+        vaultContainer = container;
+        vaultContainer.start();
+
+        VaultConnector connector = createConnector(vaultContainer, "myroot");
+
+        // Create secret at nested path
+        String nestedPath = mountPath + "/app/database/credentials";
+        connector.putSecret(nestedPath, "username", "dbuser");
+        connector.putSecret(nestedPath, "password", "dbpass");
+
+        // Retrieve from nested path
+        assertEquals("dbuser", connector.getSecret(nestedPath, "username"),
+            String.format("Should handle nested paths in %s", version));
+        assertEquals("dbpass", connector.getSecret(nestedPath, "password"),
+            String.format("Should handle nested paths in %s", version));
+    }
+}
+
+// Made with Bob

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorKvVersionTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorKvVersionTestCase.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -17,7 +18,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.vault.VaultContainer;
-import org.wildfly.security.hashicorp.vault.KvVersionTestHelper.KvTestConfig;
 import org.wildfly.security.hashicorp.vault.KvVersionTestHelper.KvVersion;
 
 import io.github.jopenlibs.vault.SslConfig;
@@ -88,13 +88,20 @@ public class VaultConnectorKvVersionTestCase {
         );
     }
 
-    private VaultConnector createConnector(VaultContainer<?> container, String token) throws VaultException {
+    private VaultConnector createConnector(VaultContainer<?> container, String token, KvVersion version, String mountPath) throws VaultException {
+        // Create predicate that returns true for KV v1 mounts
+        Predicate<String> kvV1Predicate = version == KvVersion.V1
+            ? path -> path.equals(mountPath) || path.startsWith(mountPath + "/")
+            : path -> false;
+
         VaultConnector connector = new VaultConnector(
             container.getHttpHostAddress(),
             token,
             "admin",
             new SslConfig().verify(true).build(),
-            true
+            true,
+            null,
+            kvV1Predicate
         );
         connector.configure();
         return connector;
@@ -110,7 +117,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
         String secret = connector.getSecret(mountPath + "/testing1", "top_secret");
 
         assertEquals("password123", secret,
@@ -123,7 +130,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Put a new secret
         connector.putSecret(mountPath + "/testing1", "new_secret", "newvalue123");
@@ -140,7 +147,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Verify original value
         String original = connector.getSecret(mountPath + "/testing1", "top_secret");
@@ -161,7 +168,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Verify secret exists
         String original = connector.getSecret(mountPath + "/testing1", "top_secret");
@@ -186,7 +193,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Verify both keys exist initially
         assertEquals("secretpass", connector.getSecret(mountPath + "/testing2", "dbuser"));
@@ -208,7 +215,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Verify both keys exist
         assertNotNull(connector.getSecret(mountPath + "/testing2", "dbuser"));
@@ -234,7 +241,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         String result = connector.getSecret(mountPath + "/nonexistent", "somekey");
         assertNull(result,
@@ -247,7 +254,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         String result = connector.getSecret(mountPath + "/testing1", "nonexistent_key");
         assertNull(result,
@@ -268,7 +275,11 @@ public class VaultConnectorKvVersionTestCase {
             true
         );
 
-        assertThrows(VaultException.class, connector::configure,
+        // Configure succeeds with lazy initialization, but actual operation should fail
+        connector.configure();
+
+        // Try to use the connector - this should trigger lazy initialization and fail
+        assertThrows(VaultException.class, () -> connector.getSecret(mountPath + "/test", "key"),
             String.format("Should throw VaultException for invalid token in %s", version));
     }
 
@@ -282,7 +293,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         var keys = connector.getKeysForPath(mountPath + "/testing2");
         assertNotNull(keys, String.format("Should return keys for path in %s", version));
@@ -298,7 +309,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         VaultException ex = assertThrows(VaultException.class,
             () -> connector.getKeysForPath(mountPath + "/nonexistent"),
@@ -318,7 +329,7 @@ public class VaultConnectorKvVersionTestCase {
         vaultContainer = container;
         vaultContainer.start();
 
-        VaultConnector connector = createConnector(vaultContainer, "myroot");
+        VaultConnector connector = createConnector(vaultContainer, "myroot", version, mountPath);
 
         // Create secret at nested path
         String nestedPath = mountPath + "/app/database/credentials";

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorKvVersionTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorKvVersionTestCase.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -94,19 +93,12 @@ public class VaultConnectorKvVersionTestCase {
     }
 
     private VaultConnector createConnector(VaultContainer<?> container, String token, KvVersion version, String mountPath) throws VaultException {
-        // Create predicate that returns true for KV v1 mounts
-        Predicate<String> kvV1Predicate = version == KvVersion.V1
-            ? path -> path.equals(mountPath) || path.startsWith(mountPath + "/")
-            : path -> false;
-
         VaultConnector connector = new VaultConnector(
             container.getHttpHostAddress(),
             token,
             "admin",
             new SslConfig().verify(true).build(),
-            true,
-            null,
-            kvV1Predicate
+            true
         );
         connector.configure();
         return connector;

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorMutualTlsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorMutualTlsTestCase.java
@@ -92,7 +92,8 @@ public class VaultConnectorMutualTlsTestCase {
 
             VaultConnector connector = new VaultConnector(
                     vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", wrongClientConfig, true);
-            assertThrows(VaultException.class, connector::configure);
+            connector.configure();
+            assertThrows(VaultException.class, () -> connector.getSecret("secret/testing1", "top_secret"));
         } finally {
             VaultTestUtils.cleanupDir(wrongCertDir);
         }
@@ -111,7 +112,8 @@ public class VaultConnectorMutualTlsTestCase {
 
         VaultConnector connector = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", trustOnlyConfig, true);
-        assertThrows(VaultException.class, connector::configure);
+        connector.configure();
+        assertThrows(VaultException.class, () -> connector.getSecret("secret/testing1", "top_secret"));
     }
 
     /**
@@ -139,7 +141,8 @@ public class VaultConnectorMutualTlsTestCase {
             SslConfig sslConfig = new SslConfig().verify(true).build();
             VaultConnector connector = new VaultConnector(
                     vaultTestContainer.composeHttpsHostAddress(), "", null, sslConfig, true, wrongSslContext);
-            assertThrows(VaultException.class, connector::configure);
+            connector.configure();
+            assertThrows(VaultException.class, () -> connector.getSecret("secret/testing1", "top_secret"));
         } finally {
             VaultTestUtils.cleanupDir(wrongCertDir);
         }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorMutualTlsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorMutualTlsTestCase.java
@@ -4,6 +4,19 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.net.ssl.SSLContext;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wildfly.security.hashicorp.vault.auth.TlsCertAuthConfig;
+
 import io.github.jopenlibs.vault.SslConfig;
 import io.github.jopenlibs.vault.VaultException;
 import io.smallrye.certs.CertificateFiles;
@@ -11,17 +24,6 @@ import io.smallrye.certs.CertificateGenerator;
 import io.smallrye.certs.CertificateRequest;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.PemCertificateFiles;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.wildfly.security.hashicorp.vault.auth.TlsCertAuthConfig;
-
-import javax.net.ssl.SSLContext;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Negative TLS tests with mutual TLS enforcement ({@code tls_require_and_verify_client_cert = true}).

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorMutualTlsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorMutualTlsTestCase.java
@@ -9,12 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.wildfly.security.credential.store.CredentialStoreException;
 import org.wildfly.security.hashicorp.vault.auth.TlsCertAuthConfig;
 
 import io.github.jopenlibs.vault.SslConfig;
@@ -67,6 +69,20 @@ public class VaultConnectorMutualTlsTestCase {
     }
 
     /**
+     * Helper method to get a secret value using the new alias-based API.
+     */
+    private String getSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        Map<String, Object> data = connector.getSecretData(alias);
+        if (data == null) {
+            return null;
+        }
+        return KeyPathResolver.resolveKeyPath(data, key);
+    }
+
+    /**
      * Verify that Vault rejects the TLS handshake when a client certificate signed by a different CA
      * is presented. The server requires mutual TLS and the client cert CA is not in {@code tls_client_ca_file}.
      */
@@ -93,7 +109,7 @@ public class VaultConnectorMutualTlsTestCase {
             VaultConnector connector = new VaultConnector(
                     vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", wrongClientConfig, true);
             connector.configure();
-            assertThrows(VaultException.class, () -> connector.getSecret("secret/testing1", "top_secret"));
+            assertThrows(CredentialStoreException.class, () -> getSecret(connector, "secret/testing1", "top_secret"));
         } finally {
             VaultTestUtils.cleanupDir(wrongCertDir);
         }
@@ -113,7 +129,7 @@ public class VaultConnectorMutualTlsTestCase {
         VaultConnector connector = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", trustOnlyConfig, true);
         connector.configure();
-        assertThrows(VaultException.class, () -> connector.getSecret("secret/testing1", "top_secret"));
+        assertThrows(CredentialStoreException.class, () -> getSecret(connector, "secret/testing1", "top_secret"));
     }
 
     /**
@@ -142,7 +158,7 @@ public class VaultConnectorMutualTlsTestCase {
             VaultConnector connector = new VaultConnector(
                     vaultTestContainer.composeHttpsHostAddress(), "", null, sslConfig, true, wrongSslContext);
             connector.configure();
-            assertThrows(VaultException.class, () -> connector.getSecret("secret/testing1", "top_secret"));
+            assertThrows(CredentialStoreException.class, () -> getSecret(connector, "secret/testing1", "top_secret"));
         } finally {
             VaultTestUtils.cleanupDir(wrongCertDir);
         }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTestCase.java
@@ -9,9 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.vault.VaultContainer;
+import org.wildfly.security.credential.store.CredentialStoreException;
 
 import io.github.jopenlibs.vault.SslConfig;
 import io.github.jopenlibs.vault.VaultException;
@@ -19,6 +22,51 @@ import io.github.jopenlibs.vault.VaultException;
 public class VaultConnectorTestCase {
 
     VaultContainer<?> vaultTestContainer;
+
+    /**
+     * Helper method to get a secret value using the new alias-based API.
+     * Converts old-style path+key calls to new VaultAlias format.
+     *
+     * @param connector the VaultConnector instance
+     * @param path the full path (e.g., "secret/testing1")
+     * @param key the key name
+     * @return the secret value, or null if not found
+     */
+    private String getSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        // Extract mount path and secret path from full path
+        // Assuming default mount "secret" for these tests
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        Map<String, Object> data = connector.getSecretData(alias);
+        if (data == null) {
+            return null;
+        }
+        return KeyPathResolver.resolveKeyPath(data, key);
+    }
+
+    /**
+     * Helper method to put a secret value using the new alias-based API.
+     */
+    private void putSecret(VaultConnector connector, String path, String key, String value) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        connector.putSecretData(alias, value);
+    }
+
+    /**
+     * Helper method to remove a secret value using the new alias-based API.
+     */
+    private void removeSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        connector.removeSecretData(alias);
+    }
 
     @AfterEach
     public void cleanup() {
@@ -48,7 +96,7 @@ public class VaultConnectorTestCase {
         // Test vault service
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "myroot", "secret/testing1", new SslConfig().verify(true).build(), true);
         vaultService.configure();
-        assertEquals("password123", vaultService.getSecret("secret/testing1", "top_secret"));
+        assertEquals("password123", getSecret(vaultService, "secret/testing1", "top_secret"));
     }
 
     @Test
@@ -59,9 +107,9 @@ public class VaultConnectorTestCase {
         // Test vault service
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "myroot", "secret/testing1", new SslConfig().verify(true).build(), true);
         vaultService.configure();
-        vaultService.putSecret("secret/testing1", "top_secret2", "password2");
+        putSecret(vaultService, "secret/testing1", "top_secret2", "password2");
 
-        assertEquals("password2", vaultService.getSecret("secret/testing1", "top_secret2"));
+        assertEquals("password2", getSecret(vaultService, "secret/testing1", "top_secret2"));
     }
 
     @Test
@@ -74,13 +122,13 @@ public class VaultConnectorTestCase {
         vaultService.configure();
 
         // First verify the secret exists
-        String originalSecret = vaultService.getSecret("secret/testing1", "top_secret");
+        String originalSecret = getSecret(vaultService, "secret/testing1", "top_secret");
         assertEquals("password123", originalSecret);
 
         // Remove the secret
-        vaultService.removeSecret("secret/testing1", "top_secret");
+        removeSecret(vaultService, "secret/testing1", "top_secret");
 
-        assertNull(vaultService.getSecret("secret/testing1", "top_secret"));
+        assertNull(getSecret(vaultService, "secret/testing1", "top_secret"));
         // If we get here, the test should fail because exception was expected
 
     }
@@ -101,8 +149,8 @@ public class VaultConnectorTestCase {
         // Test vault service with incorrect token - this should throw VaultException when attempting to use it
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "incorrect-token", "admin", new SslConfig().verify(true).build(), true);
         vaultService.configure();
-        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"),
-                "VaultException should be thrown due to authentication failure");
+        assertThrows(CredentialStoreException.class, () -> getSecret(vaultService, "secret/testing1", "top_secret"),
+                "CredentialStoreException should be thrown due to authentication failure");
     }
 
     @Test
@@ -113,7 +161,7 @@ public class VaultConnectorTestCase {
         // Test vault service
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "myroot", "admin", new SslConfig().verify(true).build(), true);
         vaultService.configure();
-        vaultService.removeSecret("secret/testing1", "top_secret");
+        removeSecret(vaultService, "secret/testing1", "top_secret");
     }
 
     // =====================================================================
@@ -164,7 +212,7 @@ public class VaultConnectorTestCase {
                 vaultTestContainer.getHttpHostAddress(), "myroot", "admin",
                 new SslConfig().verify(true).build(), true);
         connector.configure();
-        assertNull(connector.getSecret("secret/nonexistent", "somekey"));
+        assertNull(getSecret(connector, "secret/nonexistent", "somekey"));
     }
 
     /**
@@ -175,8 +223,8 @@ public class VaultConnectorTestCase {
     public void testGetSecretForbiddenWithRestrictedToken() throws Exception {
         startVaultWithRestrictedPolicy();
         VaultConnector connector = createRestrictedConnector();
-        VaultException ex = assertThrows(VaultException.class,
-                () -> connector.getSecret("secret/my-secret", "my-value"));
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+                () -> getSecret(connector, "secret/my-secret", "my-value"));
         assertTrue(ex.getMessage().contains("Forbidden") || ex.getMessage().contains("403"),
                 "Expected 'Forbidden' or '403' in message, got: " + ex.getMessage());
     }
@@ -189,8 +237,8 @@ public class VaultConnectorTestCase {
     public void testPutSecretForbiddenWithRestrictedToken() throws Exception {
         startVaultWithRestrictedPolicy();
         VaultConnector connector = createRestrictedConnector();
-        VaultException ex = assertThrows(VaultException.class,
-                () -> connector.putSecret("secret/testing1", "newkey", "newvalue"));
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+                () -> putSecret(connector, "secret/testing1", "newkey", "newvalue"));
         assertTrue(ex.getMessage().contains("Forbidden") || ex.getMessage().contains("403"),
                 "Expected 'Forbidden' or '403' in message, got: " + ex.getMessage());
     }
@@ -203,8 +251,8 @@ public class VaultConnectorTestCase {
     public void testRemoveSecretForbiddenOnDeleteWithRestrictedToken() throws Exception {
         startVaultWithRestrictedPolicy();
         VaultConnector connector = createRestrictedConnector();
-        VaultException ex = assertThrows(VaultException.class,
-                () -> connector.removeSecret("secret/testing1", "top_secret"));
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+                () -> removeSecret(connector, "secret/testing1", "top_secret"));
         assertTrue(ex.getMessage().contains("Forbidden") || ex.getMessage().contains("403"),
                 "Expected 'Forbidden' or '403' in message, got: " + ex.getMessage());
     }
@@ -217,57 +265,14 @@ public class VaultConnectorTestCase {
     public void testRemoveSecretForbiddenOnWriteBackWithRestrictedToken() throws Exception {
         startVaultWithRestrictedPolicy();
         VaultConnector connector = createRestrictedConnector();
-        VaultException ex = assertThrows(VaultException.class,
-                () -> connector.removeSecret("secret/testing2", "dbuser"));
+        CredentialStoreException ex = assertThrows(CredentialStoreException.class,
+                () -> removeSecret(connector, "secret/testing2", "dbuser"));
         assertTrue(ex.getMessage().contains("Forbidden") || ex.getMessage().contains("403"),
                 "Expected 'Forbidden' or '403' in message, got: " + ex.getMessage());
     }
 
-    /**
-     * Read keys from a non-existent path.
-     * Test passes when {@link VaultException} is thrown with a "Path does not exist" message.
-     */
-    @Test
-    public void testGetKeysForPathThrowsForNonExistentPath() throws Exception {
-        startVaultTestContainer();
-        VaultConnector connector = new VaultConnector(
-                vaultTestContainer.getHttpHostAddress(), "myroot", "admin",
-                new SslConfig().verify(true).build(), true);
-        connector.configure();
-        VaultException ex = assertThrows(VaultException.class,
-                () -> connector.getKeysForPath("secret/nonexistent"));
-        assertTrue(ex.getMessage().contains("Path does not exist"),
-                "Expected 'Path does not exist' in message, got: " + ex.getMessage());
-    }
-
-    /**
-     * List items at a path using a token that has no list capability.
-     * Test passes when {@link VaultException} is thrown indicating forbidden access.
-     */
-    @Test
-    public void testListAllItemsAtPathForbiddenWithRestrictedToken() throws Exception {
-        startVaultWithRestrictedPolicy();
-        VaultConnector connector = createRestrictedConnector();
-        VaultException ex = assertThrows(VaultException.class,
-                () -> connector.listAllItemsAtPath("secret/"));
-        assertTrue(ex.getMessage().contains("Forbidden") || ex.getMessage().contains("403"),
-                "Expected 'Forbidden' or '403' in message, got: " + ex.getMessage());
-    }
-
-    /**
-     * List items at a non-existent path.
-     * Test passes when {@link VaultException} is thrown with a "Path not found" message.
-     */
-    @Test
-    public void testListAllItemsAtPathThrowsForNonExistentPath() throws Exception {
-        startVaultTestContainer();
-        VaultConnector connector = new VaultConnector(
-                vaultTestContainer.getHttpHostAddress(), "myroot", "admin",
-                new SslConfig().verify(true).build(), true);
-        connector.configure();
-        VaultException ex = assertThrows(VaultException.class,
-                () -> connector.listAllItemsAtPath("secret/metadata/nonexistent/deep"));
-        assertTrue(ex.getMessage().contains("Path not found") || ex.getMessage().contains("404"),
-                "Expected 'Path not found' or '404' in message, got: " + ex.getMessage());
-    }
+    // NOTE: Tests for getKeysForPath() and listAllItemsAtPath() have been removed
+    // as these methods are no longer part of the VaultConnector API.
+    // The new alias-based API focuses on individual secret operations rather than
+    // path-level listing operations.
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTestCase.java
@@ -4,16 +4,17 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.VaultException;
-import org.testcontainers.vault.VaultContainer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.vault.VaultContainer;
+
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
 
 public class VaultConnectorTestCase {
 
@@ -71,11 +72,11 @@ public class VaultConnectorTestCase {
         // Test vault service
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "myroot", "secret/testing1", new SslConfig().verify(true).build(), true);
         vaultService.configure();
-        
+
         // First verify the secret exists
         String originalSecret = vaultService.getSecret("secret/testing1", "top_secret");
         assertEquals("password123", originalSecret);
-        
+
         // Remove the secret
         vaultService.removeSecret("secret/testing1", "top_secret");
 

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTestCase.java
@@ -98,9 +98,10 @@ public class VaultConnectorTestCase {
                 );
         vaultTestContainer.start();
 
-        // Test vault service with incorrect token - this should throw VaultException during configure()
+        // Test vault service with incorrect token - this should throw VaultException when attempting to use it
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "incorrect-token", "admin", new SslConfig().verify(true).build(), true);
-        assertThrows(VaultException.class, vaultService::configure,
+        vaultService.configure();
+        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"),
                 "VaultException should be thrown due to authentication failure");
     }
 

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
@@ -108,7 +108,7 @@ public class VaultConnectorTlsAuthTestCase {
     @NullAndEmptySource
     @ValueSource(strings = {"  ", "\t", "\n"})
     public void testGetSecretFromVaultService(final String token) throws Exception {
-        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), token, "secret/testing1", permissibleSslAuthConfig, true);
+        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), token, null, permissibleSslAuthConfig, true);
         vaultService.configure();
         assertEquals("password123", getSecret(vaultService, "secret/testing1", "top_secret"));
     }
@@ -119,7 +119,7 @@ public class VaultConnectorTlsAuthTestCase {
      */
     @Test
     public void testGetSecretFromVaultServiceInvalidToken() throws Exception {
-        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "invalidToken", "secret/testing1", new SslConfig().verify(true), true);
+        VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "invalidToken", null, new SslConfig().verify(true), true);
         vaultService.configure();
         assertThrows(CredentialStoreException.class, () -> getSecret(vaultService, "secret/testing1", "top_secret"),
                 "Correct SSL auth config was provided but token was non-empty and invalid. This should fail.");
@@ -132,7 +132,7 @@ public class VaultConnectorTlsAuthTestCase {
      */
     @Test
     public void testRemoveSecretFromVaultService() throws Exception {
-        final VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", permissibleSslAuthConfig, true);
+        final VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "", null, permissibleSslAuthConfig, true);
         vaultService.configure();
 
         final String originalSecret = getSecret(vaultService, "secret/testing1", "top_secret");

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
@@ -92,9 +92,10 @@ public class VaultConnectorTlsAuthTestCase {
      * Test will fail since the connector will try to use the token to authenticate.
      */
     @Test
-    public void testGetSecretFromVaultServiceInvalidToken() {
+    public void testGetSecretFromVaultServiceInvalidToken() throws Exception {
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "invalidToken", "secret/testing1", new SslConfig().verify(true), true);
-        assertThrows(VaultException.class, vaultService::configure,
+        vaultService.configure();
+        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"),
                 "Correct SSL auth config was provided but token was non-empty and invalid. This should fail.");
     }
 
@@ -143,7 +144,8 @@ public class VaultConnectorTlsAuthTestCase {
 
             VaultConnector vaultService = new VaultConnector(
                     vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", wrongClientConfig, true);
-            assertThrows(VaultException.class, vaultService::configure);
+            vaultService.configure();
+            assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"));
         } finally {
             VaultTestUtils.cleanupDir(wrongCertDir);
         }
@@ -163,6 +165,7 @@ public class VaultConnectorTlsAuthTestCase {
 
         VaultConnector vaultService = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", trustOnlyConfig, true);
-        assertThrows(VaultException.class, vaultService::configure);
+        vaultService.configure();
+        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"));
     }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.wildfly.security.credential.store.CredentialStoreException;
 import org.wildfly.security.hashicorp.vault.auth.TlsCertAuthConfig;
 
 import io.github.jopenlibs.vault.SslConfig;
@@ -75,16 +77,40 @@ public class VaultConnectorTlsAuthTestCase {
     }
 
     /**
+     * Helper method to get a secret value using the new alias-based API.
+     */
+    private String getSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        Map<String, Object> data = connector.getSecretData(alias);
+        if (data == null) {
+            return null;
+        }
+        return KeyPathResolver.resolveKeyPath(data, key);
+    }
+
+    /**
+     * Helper method to remove a secret value using the new alias-based API.
+     */
+    private void removeSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        connector.removeSecretData(alias);
+    }
+
+    /**
      * Configure vault connector with proper SSL config and no token and obtain a secret from the vault.
      * Test will succeed when connector properly uses login by crt auth method and reuses obtained token.
      */
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {"  ", "\t", "\n"})
-    public void testGetSecretFromVaultService(final String token) throws VaultException {
+    public void testGetSecretFromVaultService(final String token) throws Exception {
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), token, "secret/testing1", permissibleSslAuthConfig, true);
         vaultService.configure();
-        assertEquals("password123", vaultService.getSecret("secret/testing1", "top_secret"));
+        assertEquals("password123", getSecret(vaultService, "secret/testing1", "top_secret"));
     }
 
     /**
@@ -95,7 +121,7 @@ public class VaultConnectorTlsAuthTestCase {
     public void testGetSecretFromVaultServiceInvalidToken() throws Exception {
         VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "invalidToken", "secret/testing1", new SslConfig().verify(true), true);
         vaultService.configure();
-        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"),
+        assertThrows(CredentialStoreException.class, () -> getSecret(vaultService, "secret/testing1", "top_secret"),
                 "Correct SSL auth config was provided but token was non-empty and invalid. This should fail.");
     }
 
@@ -109,12 +135,12 @@ public class VaultConnectorTlsAuthTestCase {
         final VaultConnector vaultService = new VaultConnector(vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", permissibleSslAuthConfig, true);
         vaultService.configure();
 
-        final String originalSecret = vaultService.getSecret("secret/testing1", "top_secret");
+        final String originalSecret = getSecret(vaultService, "secret/testing1", "top_secret");
         assertEquals("password123", originalSecret);
 
-        vaultService.removeSecret("secret/testing1", "top_secret");
+        removeSecret(vaultService, "secret/testing1", "top_secret");
 
-        assertNull(vaultService.getSecret("secret/testing1", "top_secret"));
+        assertNull(getSecret(vaultService, "secret/testing1", "top_secret"));
     }
 
     /**
@@ -145,7 +171,7 @@ public class VaultConnectorTlsAuthTestCase {
             VaultConnector vaultService = new VaultConnector(
                     vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", wrongClientConfig, true);
             vaultService.configure();
-            assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"));
+            assertThrows(CredentialStoreException.class, () -> getSecret(vaultService, "secret/testing1", "top_secret"));
         } finally {
             VaultTestUtils.cleanupDir(wrongCertDir);
         }
@@ -166,6 +192,6 @@ public class VaultConnectorTlsAuthTestCase {
         VaultConnector vaultService = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(), "", "secret/testing1", trustOnlyConfig, true);
         vaultService.configure();
-        assertThrows(VaultException.class, () -> vaultService.getSecret("secret/testing1", "top_secret"));
+        assertThrows(CredentialStoreException.class, () -> getSecret(vaultService, "secret/testing1", "top_secret"));
     }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
@@ -4,13 +4,14 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.VaultException;
-import io.smallrye.certs.CertificateFiles;
-import io.smallrye.certs.CertificateGenerator;
-import io.smallrye.certs.CertificateRequest;
-import io.smallrye.certs.Format;
-import io.smallrye.certs.PemCertificateFiles;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,13 +20,13 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.wildfly.security.hashicorp.vault.auth.TlsCertAuthConfig;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
+import io.smallrye.certs.CertificateFiles;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.PemCertificateFiles;
 
 /**
  * Set of tests verifying functionality of VaultConnector when using TLS certificate authentication method

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorValidationTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorValidationTestCase.java
@@ -4,15 +4,16 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.VaultException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
 
 /**
  * Unit tests for input validation in {@link VaultConnector}.

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorValidationTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorValidationTestCase.java
@@ -11,14 +11,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.wildfly.security.credential.store.CredentialStoreException;
 
 import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.VaultException;
 
 /**
- * Unit tests for input validation in {@link VaultConnector}.
+ * Unit tests for input validation in {@link VaultConnector} with the new alias-based API.
  * These tests verify null/empty guard clauses without needing a running Vault instance,
  * since validation throws before any Vault API call is made.
+ *
+ * NOTE: With the new alias-based API, validation happens at the VaultAlias parsing level,
+ * so these tests now validate alias format rather than individual path/key parameters.
  */
 public class VaultConnectorValidationTestCase {
 
@@ -29,97 +32,65 @@ public class VaultConnectorValidationTestCase {
         connector = new VaultConnector("http://dummy", "token", null, new SslConfig(), true);
     }
 
-    // --- getSecret validation ---
+    // --- Alias validation ---
 
     /**
-     * Call {@code getSecret} with null, empty, or blank path values.
-     * Test passes when {@link VaultException} is thrown before any vault interaction.
-     */
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"   ", "\t"})
-    public void testGetSecretInvalidPath(String path) {
-        assertThrows(VaultException.class, () -> connector.getSecret(path, "key"));
-    }
-
-    /**
-     * Call {@code getSecret} with null, empty, or blank key values.
-     * Test passes when {@link VaultException} is thrown before any vault interaction.
-     */
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"   ", "\t"})
-    public void testGetSecretInvalidKey(String key) {
-        assertThrows(VaultException.class, () -> connector.getSecret("secret/path", key));
-    }
-
-    // --- putSecret validation ---
-
-    /**
-     * Call {@code putSecret} with null, empty, or blank path values.
-     * Test passes when {@link VaultException} is thrown before any vault interaction.
-     */
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"   ", "\t"})
-    public void testPutSecretInvalidPath(String path) {
-        assertThrows(VaultException.class, () -> connector.putSecret(path, "key", "value"));
-    }
-
-    /**
-     * Call {@code putSecret} with null, empty, or blank key values.
-     * Test passes when {@link VaultException} is thrown before any vault interaction.
-     */
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"   ", "\t"})
-    public void testPutSecretInvalidKey(String key) {
-        assertThrows(VaultException.class, () -> connector.putSecret("secret/path", key, "value"));
-    }
-
-    /**
-     * Call {@code putSecret} with a {@code null} value.
-     * Test passes when {@link VaultException} is thrown before any vault interaction.
+     * Test that null alias throws CredentialStoreException.
      */
     @Test
-    public void testPutSecretNullValue() {
-        assertThrows(VaultException.class, () -> connector.putSecret("secret/path", "key", null));
-    }
-
-    // --- removeSecret validation ---
-
-    /**
-     * Call {@code removeSecret} with null, empty, or blank path values.
-     * Test passes when {@link VaultException} is thrown before any vault interaction.
-     */
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"   ", "\t"})
-    public void testRemoveSecretInvalidPath(String path) {
-        assertThrows(VaultException.class, () -> connector.removeSecret(path, "key"));
+    public void testNullAlias() {
+        assertThrows(CredentialStoreException.class, () -> connector.getSecretData(null));
+        assertThrows(CredentialStoreException.class, () -> connector.putSecretData(null, "value"));
+        assertThrows(CredentialStoreException.class, () -> connector.removeSecretData(null));
     }
 
     /**
-     * Call {@code removeSecret} with null, empty, or blank key values.
-     * Test passes when {@link VaultException} is thrown before any vault interaction.
+     * Test that null value for putSecretData throws CredentialStoreException.
      */
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = {"   ", "\t"})
-    public void testRemoveSecretInvalidKey(String key) {
-        assertThrows(VaultException.class, () -> connector.removeSecret("secret/path", key));
+    @Test
+    public void testPutSecretNullValue() throws Exception {
+        VaultAlias alias = VaultAlias.parse("#test?key");
+        assertThrows(CredentialStoreException.class, () -> connector.putSecretData(alias, null));
     }
-
-    // --- listAllItemsAtPath validation ---
 
     /**
-     * Call {@code listAllItemsAtPath} with null, empty, or blank path values.
-     * Test passes when {@link VaultException} is thrown before any vault interaction.
+     * Test that invalid alias formats throw CredentialStoreException during parsing.
+     * These tests verify VaultAlias.parse() validation.
      */
     @ParameterizedTest
     @NullAndEmptySource
-    @ValueSource(strings = {"   ", "\t"})
-    public void testListAllItemsAtPathInvalidPath(String path) {
-        assertThrows(VaultException.class, () -> connector.listAllItemsAtPath(path));
+    @ValueSource(strings = {"   ", "\t", "\n"})
+    public void testInvalidAliasFormat(String alias) {
+        assertThrows(CredentialStoreException.class, () -> VaultAlias.parse(alias));
     }
+
+    /**
+     * Test that alias missing required delimiter (?) throws CredentialStoreException.
+     */
+    @Test
+    public void testAliasMissingKeyDelimiter() {
+        assertThrows(CredentialStoreException.class, () -> VaultAlias.parse("#test"));
+        assertThrows(CredentialStoreException.class, () -> VaultAlias.parse("#test/path"));
+    }
+
+    /**
+     * Test that alias with empty secret path throws CredentialStoreException.
+     */
+    @Test
+    public void testAliasEmptySecretPath() {
+        assertThrows(CredentialStoreException.class, () -> VaultAlias.parse("#?key"));
+        assertThrows(CredentialStoreException.class, () -> VaultAlias.parse("@mount#?key"));
+    }
+
+    /**
+     * Test that alias with empty key path throws CredentialStoreException.
+     */
+    @Test
+    public void testAliasEmptyKeyPath() {
+        assertThrows(CredentialStoreException.class, () -> VaultAlias.parse("#test?"));
+        assertThrows(CredentialStoreException.class, () -> VaultAlias.parse("#test/path?"));
+    }
+
+    // NOTE: Tests for getKeysForPath() and listAllItemsAtPath() have been removed
+    // as these methods are no longer part of the VaultConnector API.
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorWithHttpClientTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorWithHttpClientTestCase.java
@@ -4,8 +4,11 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.SslConfig;
-import io.github.jopenlibs.vault.VaultException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import javax.net.ssl.SSLContext;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,10 +17,8 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.wildfly.security.hashicorp.vault.auth.TlsCertAuthConfig;
 
-import javax.net.ssl.SSLContext;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultException;
 
 /**
  * Tests that {@link VaultConnector} works with TLS certificate authentication when a custom

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorWithHttpClientTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorWithHttpClientTestCase.java
@@ -7,6 +7,8 @@ package org.wildfly.security.hashicorp.vault;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.Map;
+
 import javax.net.ssl.SSLContext;
 
 import org.junit.jupiter.api.AfterEach;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.wildfly.security.credential.store.CredentialStoreException;
 import org.wildfly.security.hashicorp.vault.auth.TlsCertAuthConfig;
 
 import io.github.jopenlibs.vault.SslConfig;
@@ -62,12 +65,36 @@ public class VaultConnectorWithHttpClientTestCase {
     }
 
     /**
+     * Helper method to get a secret value using the new alias-based API.
+     */
+    private String getSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        Map<String, Object> data = connector.getSecretData(alias);
+        if (data == null) {
+            return null;
+        }
+        return KeyPathResolver.resolveKeyPath(data, key);
+    }
+
+    /**
+     * Helper method to remove a secret value using the new alias-based API.
+     */
+    private void removeSecret(VaultConnector connector, String path, String key) throws CredentialStoreException {
+        String secretPath = path.substring(path.indexOf('/') + 1);
+        String aliasString = "#" + secretPath + "?" + key;
+        VaultAlias alias = VaultAlias.parse(aliasString, "KVv2", "secret");
+        connector.removeSecretData(alias);
+    }
+
+    /**
      * VaultConnector#getSecret test with SSLContext and TLS client auth, without token
      */
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {"  ", "\t", "\n"})
-    public void testGetSecretWithHttpClientTlsAuth(final String token) throws VaultException {
+    public void testGetSecretWithHttpClientTlsAuth(final String token) throws Exception {
         SslConfig sslConfig = new SslConfig().verify(true).build();
         VaultConnector connector = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(),
@@ -77,14 +104,14 @@ public class VaultConnectorWithHttpClientTestCase {
                 true,
                 sslContext);
         connector.configure();
-        assertEquals("password123", connector.getSecret("secret/testing1", "top_secret"));
+        assertEquals("password123", getSecret(connector, "secret/testing1", "top_secret"));
     }
 
     /**
      * VaultConnector with SSLContext and TLS client auth, remove secret test
      */
     @Test
-    public void testRemoveSecretWithHttpClientTlsAuth() throws VaultException {
+    public void testRemoveSecretWithHttpClientTlsAuth() throws Exception {
         SslConfig sslConfig = new SslConfig().verify(true).build();
         VaultConnector connector = new VaultConnector(
                 vaultTestContainer.composeHttpsHostAddress(),
@@ -94,9 +121,9 @@ public class VaultConnectorWithHttpClientTestCase {
                 true,
                 sslContext);
         connector.configure();
-        assertEquals("password123", connector.getSecret("secret/testing1", "top_secret"));
-        connector.removeSecret("secret/testing1", "top_secret");
-        assertNull(connector.getSecret("secret/testing1", "top_secret"));
+        assertEquals("password123", getSecret(connector, "secret/testing1", "top_secret"));
+        removeSecret(connector, "secret/testing1", "top_secret");
+        assertNull(getSecret(connector, "secret/testing1", "top_secret"));
     }
 
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerHttps.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerHttps.java
@@ -231,4 +231,10 @@ public class VaultContainerHttps<SELF extends VaultContainerHttps<SELF>> extends
         VaultTestUtils.cleanupDir(this.mountedVaultCertsDir);
         VaultTestUtils.cleanupDir(this.mountedVaultConfigDir);
     }
+
+    @Override
+    public String toString() {
+        return String.format("VaultContainerHttps{image=%s, httpsPort=%d, certsDir=%s, configDir=%s}",
+                getDockerImageName(), HTTPS_PORT, mountedVaultCertsDir, mountedVaultConfigDir);
+    }
 }

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerHttps.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerHttps.java
@@ -4,21 +4,22 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.smallrye.certs.CertificateFiles;
-import io.smallrye.certs.CertificateGenerator;
-import io.smallrye.certs.CertificateRequest;
-import io.smallrye.certs.Format;
-import io.smallrye.certs.PemCertificateFiles;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.MountableFile;
 import org.testcontainers.vault.VaultContainer;
 import org.wildfly.security.hashicorp.vault.logging.JbossLoggingLogConsumer;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
+import io.smallrye.certs.CertificateFiles;
+import io.smallrye.certs.CertificateGenerator;
+import io.smallrye.certs.CertificateRequest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.PemCertificateFiles;
 
 /**
  * Represents a {@link VaultContainer} running with a secured interface.

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerKvMixed.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerKvMixed.java
@@ -67,20 +67,21 @@ public class VaultContainerKvMixed<SELF extends VaultContainerKvMixed<SELF>> ext
         this.withVaultToken(token)
             .withLogConsumer(new JbossLoggingLogConsumer(Logger.getLogger("KV_MIXED_VAULT_CONTAINER")))
             .withInitCommand(
-                // The default "secret/" mount is KV v2, keep it as-is
-                // Enable KV v1 at a separate mount point
+                // Enable KV v1 at a separate mount point first
                 "secrets enable -version=1 -path=" + KV_V1_MOUNT + " kv",
 
-                // Add test data to KV v1 mount (no /data/ segment)
-                "kv put " + KV_V1_MOUNT + "/testing1 top_secret=password123",
-                "kv put " + KV_V1_MOUNT + "/testing2 dbuser=secretpass jmsuser=jmspass",
-                "kv put " + KV_V1_MOUNT + "/my-secret my-value=s3cr3t",
+                // Upgrade the default "secret/" mount from KV v1 to KV v2
+                "kv enable-versioning " + KV_V2_MOUNT,
 
-                // Add test data to KV v2 mount (default secret/)
-                // Use same values as v1 for consistent test expectations
+                // Add test data to KV v2 mount (kv put handles /data/ path automatically)
                 "kv put " + KV_V2_MOUNT + "/testing1 top_secret=password123",
                 "kv put " + KV_V2_MOUNT + "/testing2 dbuser=secretpass jmsuser=jmspass",
                 "kv put " + KV_V2_MOUNT + "/my-secret my-value=s3cr3t",
+
+                // Add test data to KV v1 mount
+                "kv put " + KV_V1_MOUNT + "/testing1 top_secret=password123",
+                "kv put " + KV_V1_MOUNT + "/testing2 dbuser=secretpass jmsuser=jmspass",
+                "kv put " + KV_V1_MOUNT + "/my-secret my-value=s3cr3t",
 
                 // Enable transit engine for encryption tests
                 "secrets enable transit",
@@ -134,6 +135,10 @@ public class VaultContainerKvMixed<SELF extends VaultContainerKvMixed<SELF>> ext
     public boolean isV2Path(String path) {
         return path != null && path.startsWith(KV_V2_MOUNT + "/");
     }
-}
 
-// Made with Bob
+    @Override
+    public String toString() {
+        return String.format("VaultContainerKvMixed{image=%s, kvV1Mount=%s, kvV2Mount=%s, token=%s, testData=[testing1, testing2, my-secret] in both mounts}",
+                getDockerImageName(), KV_V1_MOUNT, KV_V2_MOUNT, DEFAULT_TOKEN);
+    }
+}

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerKvMixed.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerKvMixed.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.vault.VaultContainer;
+import org.wildfly.security.hashicorp.vault.logging.JbossLoggingLogConsumer;
+
+/**
+ * Represents a {@link VaultContainer} configured with both KV v1 and KV v2 engines
+ * at different mount points.
+ *
+ * <p>This container enables testing of mixed-version environments where both KV v1
+ * and v2 engines coexist. This is a common real-world scenario during migrations
+ * or in organizations with different teams using different versions.
+ *
+ * <p><strong>Mount Points:</strong>
+ * <ul>
+ *   <li><strong>KV v1:</strong> {@code secret-v1/} - Uses direct paths without versioning</li>
+ *   <li><strong>KV v2:</strong> {@code secret/} - Uses /data/ and /metadata/ paths with versioning</li>
+ * </ul>
+ *
+ * <p><strong>Path Examples:</strong>
+ * <ul>
+ *   <li>KV v1: {@code /v1/secret-v1/path/to/secret}</li>
+ *   <li>KV v2: {@code /v1/secret/data/path/to/secret}</li>
+ * </ul>
+ *
+ * <p><strong>Usage Example:</strong>
+ * <pre>{@code
+ * VaultContainerKvMixed container = new VaultContainerKvMixed("hashicorp/vault:1.13");
+ * container.start();
+ *
+ * // Access KV v1 secrets
+ * String v1Mount = container.getKvV1MountPath(); // "secret-v1"
+ *
+ * // Access KV v2 secrets
+ * String v2Mount = container.getKvV2MountPath(); // "secret"
+ * }</pre>
+ */
+public class VaultContainerKvMixed<SELF extends VaultContainerKvMixed<SELF>> extends VaultContainer<SELF> {
+
+    private static final String DEFAULT_TOKEN = "myroot";
+    private static final String KV_V1_MOUNT = "secret-v1";
+    private static final String KV_V2_MOUNT = "secret";
+
+    /**
+     * Creates a Vault container with both KV v1 and v2 engines enabled at different mount points.
+     *
+     * @param dockerImageName the Docker image name (e.g., "hashicorp/vault:1.13")
+     */
+    public VaultContainerKvMixed(String dockerImageName) {
+        this(dockerImageName, DEFAULT_TOKEN);
+    }
+
+    /**
+     * Creates a Vault container with both KV v1 and v2 engines enabled at different mount points.
+     *
+     * @param dockerImageName the Docker image name (e.g., "hashicorp/vault:1.13")
+     * @param token the root token to use for authentication
+     */
+    public VaultContainerKvMixed(String dockerImageName, String token) {
+        super(dockerImageName);
+
+        this.withVaultToken(token)
+            .withLogConsumer(new JbossLoggingLogConsumer(Logger.getLogger("KV_MIXED_VAULT_CONTAINER")))
+            .withInitCommand(
+                // The default "secret/" mount is KV v2, keep it as-is
+                // Enable KV v1 at a separate mount point
+                "secrets enable -version=1 -path=" + KV_V1_MOUNT + " kv",
+
+                // Add test data to KV v1 mount (no /data/ segment)
+                "kv put " + KV_V1_MOUNT + "/testing1 top_secret=password123",
+                "kv put " + KV_V1_MOUNT + "/testing2 dbuser=secretpass jmsuser=jmspass",
+                "kv put " + KV_V1_MOUNT + "/my-secret my-value=s3cr3t",
+
+                // Add test data to KV v2 mount (default secret/)
+                // Use same values as v1 for consistent test expectations
+                "kv put " + KV_V2_MOUNT + "/testing1 top_secret=password123",
+                "kv put " + KV_V2_MOUNT + "/testing2 dbuser=secretpass jmsuser=jmspass",
+                "kv put " + KV_V2_MOUNT + "/my-secret my-value=s3cr3t",
+
+                // Enable transit engine for encryption tests
+                "secrets enable transit",
+                "write -f transit/keys/my-key"
+            );
+    }
+
+    /**
+     * Returns the KV v1 engine mount path.
+     *
+     * @return the KV v1 mount path (default: "secret-v1")
+     */
+    public String getKvV1MountPath() {
+        return KV_V1_MOUNT;
+    }
+
+    /**
+     * Returns the KV v2 engine mount path.
+     *
+     * @return the KV v2 mount path (default: "secret")
+     */
+    public String getKvV2MountPath() {
+        return KV_V2_MOUNT;
+    }
+
+    /**
+     * Returns the root token used for authentication.
+     *
+     * @return the root token
+     */
+    public String getToken() {
+        return DEFAULT_TOKEN;
+    }
+
+    /**
+     * Helper method to determine if a given path uses the v1 mount.
+     *
+     * @param path the secret path to check
+     * @return true if the path starts with the v1 mount point
+     */
+    public boolean isV1Path(String path) {
+        return path != null && path.startsWith(KV_V1_MOUNT + "/");
+    }
+
+    /**
+     * Helper method to determine if a given path uses the v2 mount.
+     *
+     * @param path the secret path to check
+     * @return true if the path starts with the v2 mount point
+     */
+    public boolean isV2Path(String path) {
+        return path != null && path.startsWith(KV_V2_MOUNT + "/");
+    }
+}
+
+// Made with Bob

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerKvV1.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerKvV1.java
@@ -96,6 +96,10 @@ public class VaultContainerKvV1<SELF extends VaultContainerKvV1<SELF>> extends V
     public String getToken() {
         return DEFAULT_TOKEN;
     }
-}
 
-// Made with Bob
+    @Override
+    public String toString() {
+        return String.format("VaultContainerKvV1{image=%s, kvVersion=1, mountPath=%s, token=%s, testData=[testing1, testing2, my-secret]}",
+                getDockerImageName(), KV_V1_MOUNT, DEFAULT_TOKEN);
+    }
+}

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerKvV1.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultContainerKvV1.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.hashicorp.vault;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.vault.VaultContainer;
+import org.wildfly.security.hashicorp.vault.logging.JbossLoggingLogConsumer;
+
+/**
+ * Represents a {@link VaultContainer} configured with KV Secrets Engine v1.
+ *
+ * <p>This container is configured to use KV v1 at the default "secret/" mount point.
+ * KV v1 uses direct paths without the "/data/" or "/metadata/" segments used in v2.
+ *
+ * <p><strong>Key Differences from KV v2:</strong>
+ * <ul>
+ *   <li>API Path: {@code /v1/secret/path/to/secret} (no "/data/" segment)</li>
+ *   <li>No versioning support - modifications overwrite the entire secret</li>
+ *   <li>No metadata endpoint</li>
+ *   <li>Simpler data structure - direct key-value pairs</li>
+ * </ul>
+ *
+ * <p><strong>Usage Example:</strong>
+ * <pre>{@code
+ * VaultContainerKvV1 container = new VaultContainerKvV1("hashicorp/vault:1.13");
+ * container.start();
+ * // Use container.getHttpHostAddress() to connect
+ * // Use container.getToken() to authenticate
+ * }</pre>
+ */
+public class VaultContainerKvV1<SELF extends VaultContainerKvV1<SELF>> extends VaultContainer<SELF> {
+
+    private static final String DEFAULT_TOKEN = "myroot";
+    private static final String KV_V1_MOUNT = "secret";
+
+    /**
+     * Creates a Vault container with KV v1 engine enabled at the default "secret/" mount.
+     *
+     * @param dockerImageName the Docker image name (e.g., "hashicorp/vault:1.13")
+     */
+    public VaultContainerKvV1(String dockerImageName) {
+        this(dockerImageName, DEFAULT_TOKEN);
+    }
+
+    /**
+     * Creates a Vault container with KV v1 engine enabled at the default "secret/" mount.
+     *
+     * @param dockerImageName the Docker image name (e.g., "hashicorp/vault:1.13")
+     * @param token the root token to use for authentication
+     */
+    public VaultContainerKvV1(String dockerImageName, String token) {
+        super(dockerImageName);
+
+        this.withVaultToken(token)
+            .withLogConsumer(new JbossLoggingLogConsumer(Logger.getLogger("KV_V1_VAULT_CONTAINER")))
+            .withInitCommand(
+                // Disable the default KV v2 engine at secret/
+                "secrets disable secret",
+                // Enable KV v1 at secret/ mount point
+                "secrets enable -version=1 -path=" + KV_V1_MOUNT + " kv",
+                // Add test data using KV v1 paths (no /data/ segment)
+                "kv put " + KV_V1_MOUNT + "/testing1 top_secret=password123",
+                "kv put " + KV_V1_MOUNT + "/testing2 dbuser=secretpass jmsuser=jmspass",
+                "kv put " + KV_V1_MOUNT + "/my-secret my-value=s3cr3t",
+                // Enable transit engine for encryption tests
+                "secrets enable transit",
+                "write -f transit/keys/my-key"
+            );
+    }
+
+    /**
+     * Returns the KV engine mount path.
+     *
+     * @return the mount path (default: "secret")
+     */
+    public String getKvMountPath() {
+        return KV_V1_MOUNT;
+    }
+
+    /**
+     * Returns the KV engine version.
+     *
+     * @return the version number (1 for KV v1)
+     */
+    public int getKvVersion() {
+        return 1;
+    }
+
+    /**
+     * Returns the root token used for authentication.
+     *
+     * @return the root token
+     */
+    public String getToken() {
+        return DEFAULT_TOKEN;
+    }
+}
+
+// Made with Bob

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultCredentialSourceTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultCredentialSourceTestCase.java
@@ -4,18 +4,19 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.SslConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.vault.VaultContainer;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.password.interfaces.ClearPassword;
 
-import java.io.IOException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.github.jopenlibs.vault.SslConfig;
 
 public class VaultCredentialSourceTestCase {
 

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultCredentialSourceTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultCredentialSourceTestCase.java
@@ -34,8 +34,8 @@ public class VaultCredentialSourceTestCase {
         // setup and start test container with vault
         vaultTestContainer = VaultTestUtils.startVaultTestContainer();
 
-        // Start Vault service
-        VaultConnector vaultService = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "myroot", "/v1/secret/data/testing2", new SslConfig().verify(true).build(), true);
+        // Start Vault service (namespace should be null for non-Enterprise Vault)
+        VaultConnector vaultService = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "myroot", null, new SslConfig().verify(true).build(), true);
 
         // Test credential source with vault service
         VaultCredentialSource credentialSource = new VaultCredentialSource(vaultService, "secret/testing1", "top_secret");
@@ -48,8 +48,8 @@ public class VaultCredentialSourceTestCase {
         // setup and start test container with vault
         vaultTestContainer = VaultTestUtils.startVaultTestContainer();
 
-        // Start Vault service
-        VaultConnector vaultService = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "myroot", "/v1/secret/data/testing2", new SslConfig().verify(true).build(), true);
+        // Start Vault service (namespace should be null for non-Enterprise Vault)
+        VaultConnector vaultService = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "myroot", null, new SslConfig().verify(true).build(), true);
 
         // Test credential source with vault service
         VaultCredentialSource credentialSource = new VaultCredentialSource(vaultService, "secret/testing1", "incorrect");
@@ -61,8 +61,8 @@ public class VaultCredentialSourceTestCase {
     public void testGetSecretFromVaultServiceFailsWithIncorrectToken() throws Exception {
         // setup and start test container with vault
         vaultTestContainer = VaultTestUtils.startVaultTestContainer();
-        // Start Vault service
-        VaultConnector vaultConnector = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "incorrect", "/v1/secret/data/testing2", new SslConfig().verify(true).build(), true);
+        // Start Vault service (namespace should be null for non-Enterprise Vault)
+        VaultConnector vaultConnector = new VaultConnector(vaultTestContainer.getHttpHostAddress(), "incorrect", null, new SslConfig().verify(true).build(), true);
 
         // Test credential source with vault service
         VaultCredentialSource credentialSource = new VaultCredentialSource(vaultConnector, "secret/testing1", "incorrect");

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultCredentialSourceUnitTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultCredentialSourceUnitTestCase.java
@@ -4,7 +4,14 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import io.github.jopenlibs.vault.SslConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -14,13 +21,7 @@ import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.password.interfaces.ClearPassword;
 
-import java.io.IOException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.github.jopenlibs.vault.SslConfig;
 
 /**
  * Unit tests for {@link VaultCredentialSource} constructor validation,

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultTestUtils.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultTestUtils.java
@@ -4,13 +4,13 @@
  */
 package org.wildfly.security.hashicorp.vault;
 
-import org.testcontainers.vault.VaultContainer;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.stream.Stream;
+
+import org.testcontainers.vault.VaultContainer;
 
 public class VaultTestUtils {
 

--- a/src/test/java/org/wildfly/security/hashicorp/vault/auth/JwtAuthConfig.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/auth/JwtAuthConfig.java
@@ -4,12 +4,12 @@
  */
 package org.wildfly.security.hashicorp.vault.auth;
 
-import org.testcontainers.vault.VaultContainer;
-
 import java.util.AbstractMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
+
+import org.testcontainers.vault.VaultContainer;
 
 /**
  * Configure JWT authentication - enable the auth itself and configure a role

--- a/src/test/java/org/wildfly/security/hashicorp/vault/auth/JwtGenerator.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/auth/JwtGenerator.java
@@ -4,12 +4,12 @@
  */
 package org.wildfly.security.hashicorp.vault.auth;
 
+import java.security.PrivateKey;
+
 import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.lang.JoseException;
-
-import java.security.PrivateKey;
 
 /**
  * Utility to generate JWTs based on jose4j

--- a/src/test/java/org/wildfly/security/hashicorp/vault/auth/TlsCertAuthConfig.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/auth/TlsCertAuthConfig.java
@@ -4,15 +4,16 @@
  */
 package org.wildfly.security.hashicorp.vault.auth;
 
-import io.smallrye.certs.PemCertificateFiles;
-import org.testcontainers.utility.MountableFile;
-import org.testcontainers.vault.VaultContainer;
-
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+
+import org.testcontainers.utility.MountableFile;
+import org.testcontainers.vault.VaultContainer;
+
+import io.smallrye.certs.PemCertificateFiles;
 
 /**
  * Utility which will configure a vault container for TLS certificate authentication method.

--- a/src/test/java/org/wildfly/security/hashicorp/vault/logging/JbossLoggingLogConsumer.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/logging/JbossLoggingLogConsumer.java
@@ -10,9 +10,6 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.output.BaseConsumer;
 import org.testcontainers.containers.output.OutputFrame;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Jboss logging based consumer for the testcontainers container.
  */


### PR DESCRIPTION
We were running into issues identifying the version of the KV secret ending and also for multi segment engine mount paths and secret mount paths identifying which part was the mount path and which part was the secret path - to handle both cases the solution has been to define a new alias format where we can deterministically identify all of the segments.

In it's simplest form it is very similar to the current alias format with . swapped by ?

The credential store itself also retains the option to enable support for the legacy format if users are already using it.