### PR TITLE
Issue #79 | Rename KeyPathResolver to VaultKeyPathOperations for clarity

### DIFF
--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -66,7 +66,7 @@ import io.github.jopenlibs.vault.SslConfig;
  * <p>For complete documentation, see the project documentation in the {@code docs/} directory.
  *
  * @see VaultAlias
- * @see KeyPathResolver
+ * @see VaultKeyPathOperations
  */
 public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
 
@@ -273,7 +273,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
             }
 
             // Resolve the specific value using key path
-            String value = KeyPathResolver.resolveKeyPath(secretData, alias.getKeyPath());
+            String value = VaultKeyPathOperations.resolveKeyPath(secretData, alias.getKeyPath());
             if (value == null) {
                 return null; // Key not found in secret
             }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultConnector.java
@@ -331,7 +331,7 @@ public class VaultConnector {
     /**
      * Retrieve full secret data from Vault using the new alias format.
      * Returns the complete data map for the secret, which can then be
-     * processed using KeyPathResolver to extract specific values.
+     * processed using VaultKeyPathOperations to extract specific values.
      *
      * @param alias the parsed vault alias containing mount path, secret path, and engine type
      * @return map of all key-value pairs in the secret, or null if secret not found
@@ -412,7 +412,7 @@ public class VaultConnector {
                 Map<String, String> data = response.getData();
                 if (data != null) {
                     ROOT_LOGGER.vaultRetrievedSecret(path, this.vaultUrl);
-                    // Convert Map<String, String> to Map<String, Object> for KeyPathResolver
+                    // Convert Map<String, String> to Map<String, Object> for VaultKeyPathOperations
                     Map<String, Object> result = new HashMap<>();
                     result.putAll(data);
                     return result;
@@ -471,7 +471,7 @@ public class VaultConnector {
             String keyPath = alias.getKeyPath();
             if (keyPath.contains("/")) {
                 // Nested key path - need to traverse and update
-                KeyPathResolver.setNestedValue(secretData, keyPath, value);
+                VaultKeyPathOperations.setNestedValue(secretData, keyPath, value);
             } else {
                 // Simple key - direct update
                 secretData.put(keyPath, value);
@@ -528,7 +528,7 @@ public class VaultConnector {
             boolean removed;
             if (keyPath.contains("/")) {
                 // Nested key path - need to traverse and remove
-                removed = KeyPathResolver.removeNestedValue(secretData, keyPath);
+                removed = VaultKeyPathOperations.removeNestedValue(secretData, keyPath);
             } else {
                 // Simple key - direct removal
                 removed = secretData.remove(keyPath) != null;

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultCredentialSource.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultCredentialSource.java
@@ -181,7 +181,7 @@ public class VaultCredentialSource implements CredentialSource {
                     return null;
                 }
 
-                String password = KeyPathResolver.resolveKeyPath(secretData, alias.getKeyPath());
+                String password = VaultKeyPathOperations.resolveKeyPath(secretData, alias.getKeyPath());
                 if (password != null) {
                     PasswordFactory factory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR, ELYTRON_PASSWORD_PROVIDERS);
                     ClearPassword clearPassword = (ClearPassword) factory.generatePassword(

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultKeyPathOperations.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultKeyPathOperations.java
@@ -11,9 +11,16 @@ import java.util.Map;
 import org.wildfly.security.credential.store.CredentialStoreException;
 
 /**
- * Resolves key paths within Vault secret data.
+ * Utility class for performing key path operations on Vault secret data.
  *
- * <p>Supports two modes of key path resolution:
+ * <p>This private class provides three core operations for working with Vault secret data:
+ * <ul>
+ *   <li>{@link #resolveKeyPath(Map, String)} - Read: extracts values from secret data</li>
+ *   <li>{@link #setNestedValue(Map, String, String)} - Write: sets values in secret data</li>
+ *   <li>{@link #removeNestedValue(Map, String)} - Remove: removes values from secret data</li>
+ * </ul>
+ *
+ * <p><b>Operation Modes:</b> All three methods support two modes of key path resolution:
  * <ul>
  *   <li><b>Simple key lookup:</b> When the key path contains no {@code /} separator,
  *       performs a direct lookup in the data map. This supports keys with dots in their names.</li>
@@ -22,7 +29,7 @@ import org.wildfly.security.credential.store.CredentialStoreException;
  *       as part of the key name.</li>
  * </ul>
  *
- * <p>Examples:
+ * <p><b>Examples:</b>
  * <pre>
  * Map<String, Object> data = Map.of(
  *     "password", "secret123",
@@ -47,9 +54,17 @@ import org.wildfly.security.credential.store.CredentialStoreException;
  * resolveKeyPath(data, "database/host")                    → "prod.db.com"
  * resolveKeyPath(data, "database/credentials/pass")        → "secret"
  * resolveKeyPath(data, "my.app/config.key")                → "value123"  (dots in segment)
+ *
+ * // Write operations
+ * setNestedValue(data, "newKey", "value")                  // Simple set
+ * setNestedValue(data, "app/config/timeout", "30")         // Creates nested structure
+ *
+ * // Remove operations
+ * removeNestedValue(data, "password")                      // Remove simple key
+ * removeNestedValue(data, "database/credentials/pass")     // Remove nested value
  * </pre>
  */
-class KeyPathResolver {
+class VaultKeyPathOperations {
 
     /**
      * Extract value from Vault secret data using key path.

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultKeyPathOperations.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultKeyPathOperations.java
@@ -13,7 +13,7 @@ import org.wildfly.security.credential.store.CredentialStoreException;
 /**
  * Utility class for performing key path operations on Vault secret data.
  *
- * <p>This private class provides three core operations for working with Vault secret data:
+ * <p>This package-private class provides three core operations for working with Vault secret data:
  * <ul>
  *   <li>{@link #resolveKeyPath(Map, String)} - Read: extracts values from secret data</li>
  *   <li>{@link #setNestedValue(Map, String, String)} - Write: sets values in secret data</li>

--- a/src/test/java/org/wildfly/security/hashicorp/vault/ClientTLSAuthenticationWithHttpClientTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/ClientTLSAuthenticationWithHttpClientTestCase.java
@@ -63,7 +63,7 @@ public class ClientTLSAuthenticationWithHttpClientTestCase {
         if (data == null) {
             return null;
         }
-        return KeyPathResolver.resolveKeyPath(data, key);
+        return VaultKeyPathOperations.resolveKeyPath(data, key);
     }
 
     /**

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultCliInteroperabilityTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultCliInteroperabilityTestCase.java
@@ -120,7 +120,7 @@ public class VaultCliInteroperabilityTestCase {
             return null;
         }
 
-        return KeyPathResolver.resolveKeyPath(data, key);
+        return VaultKeyPathOperations.resolveKeyPath(data, key);
     }
 
     /**

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorHttpsTestCase.java
@@ -72,7 +72,7 @@ public class VaultConnectorHttpsTestCase {
         if (data == null) {
             return null;
         }
-        return KeyPathResolver.resolveKeyPath(data, key);
+        return VaultKeyPathOperations.resolveKeyPath(data, key);
     }
 
     /**

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorJwtAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorJwtAuthTestCase.java
@@ -109,7 +109,7 @@ public class VaultConnectorJwtAuthTestCase {
         if (data == null) {
             return null;
         }
-        return KeyPathResolver.resolveKeyPath(data, key);
+        return VaultKeyPathOperations.resolveKeyPath(data, key);
     }
 
     /**

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorKvVersionTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorKvVersionTestCase.java
@@ -135,7 +135,7 @@ public class VaultConnectorKvVersionTestCase {
         }
 
         // Resolve key path
-        return KeyPathResolver.resolveKeyPath(data, key);
+        return VaultKeyPathOperations.resolveKeyPath(data, key);
     }
 
     /**

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorMutualTlsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorMutualTlsTestCase.java
@@ -79,7 +79,7 @@ public class VaultConnectorMutualTlsTestCase {
         if (data == null) {
             return null;
         }
-        return KeyPathResolver.resolveKeyPath(data, key);
+        return VaultKeyPathOperations.resolveKeyPath(data, key);
     }
 
     /**

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTestCase.java
@@ -43,7 +43,7 @@ public class VaultConnectorTestCase {
         if (data == null) {
             return null;
         }
-        return KeyPathResolver.resolveKeyPath(data, key);
+        return VaultKeyPathOperations.resolveKeyPath(data, key);
     }
 
     /**

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorTlsAuthTestCase.java
@@ -87,7 +87,7 @@ public class VaultConnectorTlsAuthTestCase {
         if (data == null) {
             return null;
         }
-        return KeyPathResolver.resolveKeyPath(data, key);
+        return VaultKeyPathOperations.resolveKeyPath(data, key);
     }
 
     /**

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorWithHttpClientTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultConnectorWithHttpClientTestCase.java
@@ -75,7 +75,7 @@ public class VaultConnectorWithHttpClientTestCase {
         if (data == null) {
             return null;
         }
-        return KeyPathResolver.resolveKeyPath(data, key);
+        return VaultKeyPathOperations.resolveKeyPath(data, key);
     }
 
     /**

--- a/src/test/java/org/wildfly/security/hashicorp/vault/VaultKeyPathOperationsTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/VaultKeyPathOperationsTestCase.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.wildfly.security.credential.store.CredentialStoreException;
 
 /**
- * Unit tests for {@link KeyPathResolver} key path resolution logic.
+ * Unit tests for {@link VaultKeyPathOperations} key path operations.
  *
  * <p>This test class covers:
  * <ul>
@@ -29,9 +29,9 @@ import org.wildfly.security.credential.store.CredentialStoreException;
  *   <li>Set and remove operations for nested values</li>
  * </ul>
  *
- * <p>Test coverage target: >95% for {@link KeyPathResolver} class
+ * <p>Test coverage target: >95% for {@link VaultKeyPathOperations} class
  */
-public class KeyPathResolverTestCase {
+public class VaultKeyPathOperationsTestCase {
 
     private Map<String, Object> testData;
 
@@ -64,28 +64,28 @@ public class KeyPathResolverTestCase {
     @Test
     void testSimpleKeyWithoutDots() throws CredentialStoreException {
         // Top-level key without dots
-        String result = KeyPathResolver.resolveKeyPath(testData, "password");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "password");
         assertEquals("secret123", result);
     }
 
     @Test
     void testSimpleKeyWithDots() throws CredentialStoreException {
         // Top-level key with dots - literal match
-        String result = KeyPathResolver.resolveKeyPath(testData, "db.host");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "db.host");
         assertEquals("localhost", result);
     }
 
     @Test
     void testSimpleKeyNotFound() throws CredentialStoreException {
         // Key that doesn't exist
-        String result = KeyPathResolver.resolveKeyPath(testData, "nonexistent");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "nonexistent");
         assertNull(result);
     }
 
     @Test
     void testSimpleKeyWithDotsNotFound() throws CredentialStoreException {
         // Key with dots that doesn't exist
-        String result = KeyPathResolver.resolveKeyPath(testData, "not.found");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "not.found");
         assertNull(result);
     }
 
@@ -96,42 +96,42 @@ public class KeyPathResolverTestCase {
     @Test
     void testSingleLevelNesting() throws CredentialStoreException {
         // Single-level nested path
-        String result = KeyPathResolver.resolveKeyPath(testData, "database/host");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "database/host");
         assertEquals("prod.db.com", result);
     }
 
     @Test
     void testSingleLevelNestingInteger() throws CredentialStoreException {
         // Single-level nested path with integer value
-        String result = KeyPathResolver.resolveKeyPath(testData, "database/port");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "database/port");
         assertEquals("5432", result);
     }
 
     @Test
     void testMultiLevelNesting() throws CredentialStoreException {
         // Multi-level nested path (2 levels)
-        String result = KeyPathResolver.resolveKeyPath(testData, "database/credentials/user");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "database/credentials/user");
         assertEquals("admin", result);
     }
 
     @Test
     void testDeepNesting() throws CredentialStoreException {
         // Deep nesting (3 levels)
-        String result = KeyPathResolver.resolveKeyPath(testData, "database/credentials/pass");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "database/credentials/pass");
         assertEquals("secret", result);
     }
 
     @Test
     void testNestedPathNotFound() throws CredentialStoreException {
         // Nested path where intermediate key doesn't exist
-        String result = KeyPathResolver.resolveKeyPath(testData, "database/nonexistent/key");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "database/nonexistent/key");
         assertNull(result);
     }
 
     @Test
     void testNestedPathLeafNotFound() throws CredentialStoreException {
         // Nested path where leaf key doesn't exist
-        String result = KeyPathResolver.resolveKeyPath(testData, "database/credentials/nonexistent");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "database/credentials/nonexistent");
         assertNull(result);
     }
 
@@ -142,7 +142,7 @@ public class KeyPathResolverTestCase {
     @Test
     void testNestedPathWithDotsInKeyName() throws CredentialStoreException {
         // Nested path where segment contains dots
-        String result = KeyPathResolver.resolveKeyPath(testData, "my.app/config.key");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "my.app/config.key");
         assertEquals("value123", result);
     }
 
@@ -153,7 +153,7 @@ public class KeyPathResolverTestCase {
         teamAlpha.put("app.config", "alpha-value");
         testData.put("team.alpha", teamAlpha);
 
-        String result = KeyPathResolver.resolveKeyPath(testData, "team.alpha/app.config");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "team.alpha/app.config");
         assertEquals("alpha-value", result);
     }
 
@@ -165,7 +165,7 @@ public class KeyPathResolverTestCase {
     void testNullKeyPath() {
         // Null key path should throw exception
         assertThrows(CredentialStoreException.class, () -> {
-            KeyPathResolver.resolveKeyPath(testData, null);
+            VaultKeyPathOperations.resolveKeyPath(testData, null);
         });
     }
 
@@ -173,14 +173,14 @@ public class KeyPathResolverTestCase {
     void testEmptyKeyPath() {
         // Empty key path should throw exception
         assertThrows(CredentialStoreException.class, () -> {
-            KeyPathResolver.resolveKeyPath(testData, "");
+            VaultKeyPathOperations.resolveKeyPath(testData, "");
         });
     }
 
     @Test
     void testNullData() throws CredentialStoreException {
         // Null data map should return null
-        String result = KeyPathResolver.resolveKeyPath(null, "password");
+        String result = VaultKeyPathOperations.resolveKeyPath(null, "password");
         assertNull(result);
     }
 
@@ -188,7 +188,7 @@ public class KeyPathResolverTestCase {
     void testEmptySegmentInPath() {
         // Key path with empty segment (e.g., "database//host")
         assertThrows(CredentialStoreException.class, () -> {
-            KeyPathResolver.resolveKeyPath(testData, "database//host");
+            VaultKeyPathOperations.resolveKeyPath(testData, "database//host");
         });
     }
 
@@ -196,7 +196,7 @@ public class KeyPathResolverTestCase {
     void testLeadingSlash() {
         // Key path starting with slash
         assertThrows(CredentialStoreException.class, () -> {
-            KeyPathResolver.resolveKeyPath(testData, "/database/host");
+            VaultKeyPathOperations.resolveKeyPath(testData, "/database/host");
         });
     }
 
@@ -204,21 +204,21 @@ public class KeyPathResolverTestCase {
     void testTrailingSlash() throws CredentialStoreException {
         // Key path ending with slash - trailing empty strings are removed by split()
         // so this is equivalent to "database/host"
-        String result = KeyPathResolver.resolveKeyPath(testData, "database/host/");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "database/host/");
         assertEquals("prod.db.com", result);
     }
 
     @Test
     void testNonMapValueInTraversalPath() throws CredentialStoreException {
         // Try to traverse through a non-map value
-        String result = KeyPathResolver.resolveKeyPath(testData, "password/subkey");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "password/subkey");
         assertNull(result);
     }
 
     @Test
     void testNonMapIntermediateValue() throws CredentialStoreException {
         // Try to traverse through an integer value
-        String result = KeyPathResolver.resolveKeyPath(testData, "database/port/subkey");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "database/port/subkey");
         assertNull(result);
     }
 
@@ -226,7 +226,7 @@ public class KeyPathResolverTestCase {
     void testNullValueInData() throws CredentialStoreException {
         // Add null value to test data
         testData.put("nullValue", null);
-        String result = KeyPathResolver.resolveKeyPath(testData, "nullValue");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "nullValue");
         assertNull(result);
     }
 
@@ -236,7 +236,7 @@ public class KeyPathResolverTestCase {
         Map<String, Object> database = (Map<String, Object>) testData.get("database");
         database.put("nullField", null);
 
-        String result = KeyPathResolver.resolveKeyPath(testData, "database/nullField");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "database/nullField");
         assertNull(result);
     }
 
@@ -247,7 +247,7 @@ public class KeyPathResolverTestCase {
     @Test
     void testSetSimpleValue() throws CredentialStoreException {
         Map<String, Object> data = new HashMap<>();
-        KeyPathResolver.setNestedValue(data, "password", "newSecret");
+        VaultKeyPathOperations.setNestedValue(data, "password", "newSecret");
 
         assertEquals("newSecret", data.get("password"));
     }
@@ -255,7 +255,7 @@ public class KeyPathResolverTestCase {
     @Test
     void testSetNestedValueCreatesStructure() throws CredentialStoreException {
         Map<String, Object> data = new HashMap<>();
-        KeyPathResolver.setNestedValue(data, "database/host", "localhost");
+        VaultKeyPathOperations.setNestedValue(data, "database/host", "localhost");
 
         assertTrue(data.containsKey("database"));
         assertTrue(data.get("database") instanceof Map);
@@ -266,7 +266,7 @@ public class KeyPathResolverTestCase {
     @Test
     void testSetDeepNestedValue() throws CredentialStoreException {
         Map<String, Object> data = new HashMap<>();
-        KeyPathResolver.setNestedValue(data, "database/credentials/password", "secret");
+        VaultKeyPathOperations.setNestedValue(data, "database/credentials/password", "secret");
 
         Map<String, Object> database = (Map<String, Object>) data.get("database");
         Map<String, Object> credentials = (Map<String, Object>) database.get("credentials");
@@ -276,7 +276,7 @@ public class KeyPathResolverTestCase {
     @Test
     void testSetValueWithDotsInSegment() throws CredentialStoreException {
         Map<String, Object> data = new HashMap<>();
-        KeyPathResolver.setNestedValue(data, "my.app/config.key", "value");
+        VaultKeyPathOperations.setNestedValue(data, "my.app/config.key", "value");
 
         assertTrue(data.containsKey("my.app"));
         Map<String, Object> myApp = (Map<String, Object>) data.get("my.app");
@@ -288,7 +288,7 @@ public class KeyPathResolverTestCase {
         Map<String, Object> data = new HashMap<>();
         data.put("database", "stringValue");
 
-        KeyPathResolver.setNestedValue(data, "database/host", "localhost");
+        VaultKeyPathOperations.setNestedValue(data, "database/host", "localhost");
 
         assertTrue(data.get("database") instanceof Map);
         Map<String, Object> database = (Map<String, Object>) data.get("database");
@@ -299,7 +299,7 @@ public class KeyPathResolverTestCase {
     void testSetValueNullKeyPath() {
         Map<String, Object> data = new HashMap<>();
         assertThrows(CredentialStoreException.class, () -> {
-            KeyPathResolver.setNestedValue(data, null, "value");
+            VaultKeyPathOperations.setNestedValue(data, null, "value");
         });
     }
 
@@ -307,14 +307,14 @@ public class KeyPathResolverTestCase {
     void testSetValueEmptyKeyPath() {
         Map<String, Object> data = new HashMap<>();
         assertThrows(CredentialStoreException.class, () -> {
-            KeyPathResolver.setNestedValue(data, "", "value");
+            VaultKeyPathOperations.setNestedValue(data, "", "value");
         });
     }
 
     @Test
     void testSetValueNullData() {
         assertThrows(IllegalArgumentException.class, () -> {
-            KeyPathResolver.setNestedValue(null, "key", "value");
+            VaultKeyPathOperations.setNestedValue(null, "key", "value");
         });
     }
 
@@ -322,7 +322,7 @@ public class KeyPathResolverTestCase {
     void testSetValueEmptySegment() {
         Map<String, Object> data = new HashMap<>();
         assertThrows(CredentialStoreException.class, () -> {
-            KeyPathResolver.setNestedValue(data, "database//host", "value");
+            VaultKeyPathOperations.setNestedValue(data, "database//host", "value");
         });
     }
 
@@ -335,7 +335,7 @@ public class KeyPathResolverTestCase {
         Map<String, Object> data = new HashMap<>();
         data.put("password", "secret");
 
-        boolean removed = KeyPathResolver.removeNestedValue(data, "password");
+        boolean removed = VaultKeyPathOperations.removeNestedValue(data, "password");
         assertTrue(removed);
         assertFalse(data.containsKey("password"));
     }
@@ -349,7 +349,7 @@ public class KeyPathResolverTestCase {
         Map<String, Object> data = new HashMap<>();
         data.put("credentials", credentials);
 
-        boolean removed = KeyPathResolver.removeNestedValue(data, "credentials/pass");
+        boolean removed = VaultKeyPathOperations.removeNestedValue(data, "credentials/pass");
         assertTrue(removed);
         assertFalse(credentials.containsKey("pass"));
         assertTrue(credentials.containsKey("user")); // Other keys preserved
@@ -357,7 +357,7 @@ public class KeyPathResolverTestCase {
 
     @Test
     void testRemoveDeepNestedValue() throws CredentialStoreException {
-        boolean removed = KeyPathResolver.removeNestedValue(testData, "database/credentials/pass");
+        boolean removed = VaultKeyPathOperations.removeNestedValue(testData, "database/credentials/pass");
         assertTrue(removed);
 
         Map<String, Object> database = (Map<String, Object>) testData.get("database");
@@ -368,52 +368,52 @@ public class KeyPathResolverTestCase {
 
     @Test
     void testRemoveNonExistentSimpleKey() throws CredentialStoreException {
-        boolean removed = KeyPathResolver.removeNestedValue(testData, "nonexistent");
+        boolean removed = VaultKeyPathOperations.removeNestedValue(testData, "nonexistent");
         assertFalse(removed);
     }
 
     @Test
     void testRemoveNonExistentNestedKey() throws CredentialStoreException {
-        boolean removed = KeyPathResolver.removeNestedValue(testData, "database/nonexistent");
+        boolean removed = VaultKeyPathOperations.removeNestedValue(testData, "database/nonexistent");
         assertFalse(removed);
     }
 
     @Test
     void testRemoveFromNonExistentPath() throws CredentialStoreException {
-        boolean removed = KeyPathResolver.removeNestedValue(testData, "nonexistent/path/key");
+        boolean removed = VaultKeyPathOperations.removeNestedValue(testData, "nonexistent/path/key");
         assertFalse(removed);
     }
 
     @Test
     void testRemoveFromNonMapValue() throws CredentialStoreException {
-        boolean removed = KeyPathResolver.removeNestedValue(testData, "password/subkey");
+        boolean removed = VaultKeyPathOperations.removeNestedValue(testData, "password/subkey");
         assertFalse(removed);
     }
 
     @Test
     void testRemoveNullKeyPath() {
         assertThrows(CredentialStoreException.class, () -> {
-            KeyPathResolver.removeNestedValue(testData, null);
+            VaultKeyPathOperations.removeNestedValue(testData, null);
         });
     }
 
     @Test
     void testRemoveEmptyKeyPath() {
         assertThrows(CredentialStoreException.class, () -> {
-            KeyPathResolver.removeNestedValue(testData, "");
+            VaultKeyPathOperations.removeNestedValue(testData, "");
         });
     }
 
     @Test
     void testRemoveNullData() throws CredentialStoreException {
-        boolean removed = KeyPathResolver.removeNestedValue(null, "key");
+        boolean removed = VaultKeyPathOperations.removeNestedValue(null, "key");
         assertFalse(removed);
     }
 
     @Test
     void testRemoveEmptySegment() {
         assertThrows(CredentialStoreException.class, () -> {
-            KeyPathResolver.removeNestedValue(testData, "database//host");
+            VaultKeyPathOperations.removeNestedValue(testData, "database//host");
         });
     }
 
@@ -441,7 +441,7 @@ public class KeyPathResolverTestCase {
 
         testData.put("level1", level1);
 
-        String result = KeyPathResolver.resolveKeyPath(testData, "level1/level2/level3/level4/level5/value");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "level1/level2/level3/level4/level5/value");
         assertEquals("deep", result);
     }
 
@@ -452,29 +452,29 @@ public class KeyPathResolverTestCase {
         testData.put("key#with#hash", "value2");
         testData.put("key?with?question", "value3");
 
-        assertEquals("value1", KeyPathResolver.resolveKeyPath(testData, "key with spaces"));
-        assertEquals("value2", KeyPathResolver.resolveKeyPath(testData, "key#with#hash"));
-        assertEquals("value3", KeyPathResolver.resolveKeyPath(testData, "key?with?question"));
+        assertEquals("value1", VaultKeyPathOperations.resolveKeyPath(testData, "key with spaces"));
+        assertEquals("value2", VaultKeyPathOperations.resolveKeyPath(testData, "key#with#hash"));
+        assertEquals("value3", VaultKeyPathOperations.resolveKeyPath(testData, "key?with?question"));
     }
 
     @Test
     void testBooleanValue() throws CredentialStoreException {
         testData.put("enabled", true);
-        String result = KeyPathResolver.resolveKeyPath(testData, "enabled");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "enabled");
         assertEquals("true", result);
     }
 
     @Test
     void testNumericValue() throws CredentialStoreException {
         testData.put("count", 42);
-        String result = KeyPathResolver.resolveKeyPath(testData, "count");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "count");
         assertEquals("42", result);
     }
 
     @Test
     void testDoubleValue() throws CredentialStoreException {
         testData.put("price", 19.99);
-        String result = KeyPathResolver.resolveKeyPath(testData, "price");
+        String result = VaultKeyPathOperations.resolveKeyPath(testData, "price");
         assertEquals("19.99", result);
     }
 }


### PR DESCRIPTION
Refactors the internal `KeyPathResolver` class to `VaultKeyPathOperations` to better reflect its full scope of operations on Vault secret data.

Addresses reviewer feedback from PR #71. The original name `KeyPathResolver` only described the read operation, but the class provides three distinct operations:
  - Read: `resolveKeyPath()`
  - Write: `setNestedValue()`
  - Remove: `removeNestedValue()`
  

  ## Changes
  - Renamed `KeyPathResolver` → `VaultKeyPathOperations`
  - Enhanced class-level JavaDoc for comprehensive clarity
  - Updated all references in source and test files (14 files total)
  - Renamed test class to `VaultKeyPathOperationsTestCase`
  
  Resolves: https://github.com/wildfly-security/wildfly-elytron-hashicorp-vault/issues/79