### PR TITLE
Issue #83  | Add CI - Non-LTS Nightly workflow for Java 26

### DIFF
--- a/.github/workflows/ci-non-lts.yml
+++ b/.github/workflows/ci-non-lts.yml
@@ -4,12 +4,6 @@ on:
   schedule:
     # Run nightly at 3 AM UTC
     - cron: '0 3 * * *'
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       enabled:

--- a/.github/workflows/ci-non-lts.yml
+++ b/.github/workflows/ci-non-lts.yml
@@ -1,0 +1,205 @@
+name: CI - Non-LTS Nightly (Java 26)
+
+on:
+  schedule:
+    # Run nightly at 3 AM UTC
+    - cron: '0 3 * * *'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      enabled:
+        description: 'Run non-LTS Java 26 validation'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  build-and-test:
+    name: Build and Test - ${{ matrix.os }}
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.enabled }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+
+      - name: Capture JDK 25 (Temurin) path
+        shell: bash
+        run: echo "JAVA_HOME_25_TEMURIN=$JAVA_HOME" >> $GITHUB_ENV
+
+      - name: Set up JDK 26 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '26'
+          check-latest: true
+
+      - name: Capture JDK 26 (Temurin) path
+        shell: bash
+        run: echo "JAVA_HOME_26_TEMURIN=$JAVA_HOME" >> $GITHUB_ENV
+
+      - name: Set up JDK 26 (Semeru)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'semeru'
+          java-version: '26'
+          check-latest: true
+
+      - name: Capture JDK 26 (Semeru) path
+        shell: bash
+        run: echo "JAVA_HOME_26_SEMERU=$JAVA_HOME" >> $GITHUB_ENV
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-non-lts-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-non-lts-
+            ${{ runner.os }}-maven-
+
+      - name: Generate toolchains.xml
+        shell: bash
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/toolchains.xml << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0
+                                          http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <version>25</version>
+                <vendor>temurin</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>${JAVA_HOME_25_TEMURIN}</jdkHome>
+              </configuration>
+            </toolchain>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <version>26</version>
+                <vendor>temurin</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>${JAVA_HOME_26_TEMURIN}</jdkHome>
+              </configuration>
+            </toolchain>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <version>26</version>
+                <vendor>semeru</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>${JAVA_HOME_26_SEMERU}</jdkHome>
+              </configuration>
+            </toolchain>
+          </toolchains>
+          EOF
+
+      - name: Build with Java 25
+        shell: bash
+        run: |
+          export JAVA_HOME="${JAVA_HOME_25_TEMURIN}"
+          mvn clean install -DskipTests -B -V
+
+      - name: Test with Java 26 (Temurin)
+        if: runner.os == 'Linux'
+        id: test-java26-temurin
+        shell: bash
+        timeout-minutes: 30
+        run: |
+          mvn test -Djdk.test.version=26 -Djdk.test.vendor=temurin -B
+        continue-on-error: true
+
+      - name: Publish test results - Java 26 (Temurin) - ${{ matrix.os }}
+        if: always() && runner.os == 'Linux'
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: '**/target/surefire-reports/TEST-*.xml'
+          check_name: 'Test Results - Java 26 (Temurin) - ${{ matrix.os }}'
+          comment_mode: off
+
+      - name: Upload test results - Java 26 (Temurin) - ${{ matrix.os }}
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-java26-temurin-${{ matrix.os }}
+          path: '**/target/surefire-reports/**'
+          retention-days: 30
+
+      - name: Test with Java 26 (Semeru)
+        if: runner.os == 'Linux'
+        id: test-java26-semeru
+        shell: bash
+        timeout-minutes: 30
+        run: |
+          mvn test -Djdk.test.version=26 -Djdk.test.vendor=semeru -B
+        continue-on-error: true
+
+      - name: Publish test results - Java 26 (Semeru) - ${{ matrix.os }}
+        if: always() && runner.os == 'Linux'
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: '**/target/surefire-reports/TEST-*.xml'
+          check_name: 'Test Results - Java 26 (Semeru) - ${{ matrix.os }}'
+          comment_mode: off
+
+      - name: Upload test results - Java 26 (Semeru) - ${{ matrix.os }}
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-java26-semeru-${{ matrix.os }}
+          path: '**/target/surefire-reports/**'
+          retention-days: 30
+
+      - name: Check test results
+        if: always()
+        shell: bash
+        run: |
+          echo "Checking non-LTS Java 26 test results..."
+
+          if [ "${{ runner.os }}" == "Linux" ]; then
+            FAILED=0
+
+            if [ "${{ steps.test-java26-temurin.outcome }}" != "success" ]; then
+              echo "❌ Java 26 (Temurin) tests failed"
+              FAILED=1
+            fi
+
+            if [ "${{ steps.test-java26-semeru.outcome }}" != "success" ]; then
+              echo "❌ Java 26 (Semeru) tests failed"
+              FAILED=1
+            fi
+
+            if [ $FAILED -eq 1 ]; then
+              echo ""
+              echo "Non-LTS validation failed. Check the test result artifacts and logs above."
+              exit 1
+            else
+              echo "✅ All Java 26 test permutations passed"
+            fi
+          else
+            echo "ℹ️  Tests skipped on ${{ runner.os }} (Testcontainers requires Docker, only available on Linux runners)"
+            echo "✅ Build successful on ${{ runner.os }}"
+          fi


### PR DESCRIPTION
Implements the Non-LTS workflow documented in CI.md (lines 74-96) for testing Java 26 compatibility.

Building on @darranl's TEMP CI work, this completes the implementation by adding Semeru vendor testing as documented. 

**Changes**
  - Add `.github/workflows/ci-non-lts.yml` for Java 26 testing
  - Tests both Temurin and Semeru vendors (2 vendors × 3 OS = 6 permutations)
  - Scheduled to run daily at 3 AM UTC
  - Tests on Linux, builds on all platforms (Windows, macOS)
  - Includes `enabled` workflow input to disable during LTS transition periods
  - Follows pattern from existing CI workflows

Resolves: #83 