### PR TITLE
Issue #73 | Add wildfly-common dependency for Assert.checkNotNull

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
             <version>${version.org.jboss.logging}</version>

--- a/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStore.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import javax.net.ssl.SSLContext;
 
+import org.wildfly.common.Assert;
 import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.store.CredentialStore;
@@ -102,9 +103,7 @@ public class HashicorpVaultCredentialStore extends CredentialStoreSpi {
 
     @Override
     public void initialize(Map<String, String> attributes, CredentialStore.ProtectionParameter protectionParameter, Provider[] providers) throws CredentialStoreException {
-        if (attributes == null) {
-            throw ROOT_LOGGER.attributesCannotBeNull();
-        }
+        Assert.checkNotNullParam("attributes", attributes);
 
         // Check required attributes
         this.hostAddress = attributes.get("host-address");

--- a/src/main/java/org/wildfly/security/hashicorp/vault/JwtConfig.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/JwtConfig.java
@@ -6,6 +6,7 @@ package org.wildfly.security.hashicorp.vault;
 
 import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger.ROOT_LOGGER;
 
+import org.wildfly.common.Assert;
 import org.wildfly.common.annotation.NotNull;
 
 /**
@@ -18,9 +19,17 @@ public final class JwtConfig {
     private final String jwtProvider;
 
     public JwtConfig(@NotNull String jwt, @NotNull String jwtRole, @NotNull String jwtProvider) {
-        this.jwt = checkRequired(jwt);
-        this.jwtRole = checkRequired(jwtRole);
-        this.jwtProvider = checkRequired(jwtProvider);
+        this.jwt = checkRequired("jwt", jwt);
+        this.jwtRole = checkRequired("jwtRole", jwtRole);
+        this.jwtProvider = checkRequired("jwtProvider", jwtProvider);
+    }
+
+    private String checkRequired(String paramName, String value) throws IllegalArgumentException {
+        Assert.checkNotNullParam(paramName, value);
+        if (value.trim().isEmpty()) {
+            throw new IllegalArgumentException("Parameter '" + paramName + "' must not be empty or blank");
+        }
+        return value;
     }
 
     public String getJwt() {
@@ -33,12 +42,5 @@ public final class JwtConfig {
 
     public String getJwtProvider() {
         return jwtProvider;
-    }
-
-    private String checkRequired(String value) throws IllegalArgumentException {
-        if (value == null || value.trim().isEmpty()) {
-            throw ROOT_LOGGER.jwtMissingRequiredProperty();
-        }
-        return value;
     }
 }

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultAlias.java
@@ -6,6 +6,7 @@ package org.wildfly.security.hashicorp.vault;
 
 import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger.ROOT_LOGGER;
 
+import org.wildfly.common.Assert;
 import org.wildfly.security.credential.store.CredentialStoreException;
 
 /**
@@ -61,17 +62,23 @@ class VaultAlias extends VaultPath {
      * @throws CredentialStoreException if the engine type is invalid or any required component is null/empty
      */
     static VaultAlias create(String engineType, String mountPath, String secretPath, String keyPath) throws CredentialStoreException {
-        // Validate required parameters
-        if (engineType == null || engineType.isEmpty()) {
+        // Validate required parameters - null checks
+        Assert.checkNotNullParam("engineType", engineType);
+        Assert.checkNotNullParam("mountPath", mountPath);
+        Assert.checkNotNullParam("secretPath", secretPath);
+        Assert.checkNotNullParam("keyPath", keyPath);
+
+        // Business validation - empty checks
+        if (engineType.isEmpty()) {
             throw ROOT_LOGGER.engineTypeCannotBeEmpty("direct creation");
         }
-        if (mountPath == null || mountPath.isEmpty()) {
+        if (mountPath.isEmpty()) {
             throw ROOT_LOGGER.mountPathCannotBeEmpty("direct creation");
         }
-        if (secretPath == null || secretPath.isEmpty()) {
+        if (secretPath.isEmpty()) {
             throw ROOT_LOGGER.secretPathCannotBeEmpty("direct creation");
         }
-        if (keyPath == null || keyPath.isEmpty()) {
+        if (keyPath.isEmpty()) {
             throw ROOT_LOGGER.keyPathCannotBeEmpty("direct creation");
         }
 

--- a/src/main/java/org/wildfly/security/hashicorp/vault/VaultKeyPathOperations.java
+++ b/src/main/java/org/wildfly/security/hashicorp/vault/VaultKeyPathOperations.java
@@ -8,6 +8,7 @@ import static org.wildfly.security.hashicorp.vault._private.HashiCorpVaultLogger
 
 import java.util.Map;
 
+import org.wildfly.common.Assert;
 import org.wildfly.security.credential.store.CredentialStoreException;
 
 /**
@@ -174,9 +175,7 @@ class VaultKeyPathOperations {
         if (keyPath == null || keyPath.isEmpty()) {
             throw ROOT_LOGGER.keyPathCannotBeNullOrEmpty();
         }
-        if (data == null) {
-            throw new IllegalArgumentException("Data map cannot be null");
-        }
+        Assert.checkNotNullParam("data", data);
 
         // Check if key path contains / (nested path)
         if (!keyPath.contains("/")) {

--- a/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
+++ b/src/test/java/org/wildfly/security/hashicorp/vault/HashicorpVaultCredentialStoreTestCase.java
@@ -604,12 +604,12 @@ public class HashicorpVaultCredentialStoreTestCase {
 
     /**
      * Call {@code initialize()} with {@code null} attributes map.
-     * Test passes when {@link CredentialStoreException} is thrown.
+     * Test passes when {@link IllegalArgumentException} is thrown.
      */
     @Test
     public void testInitializeWithNullAttributes() {
         HashicorpVaultCredentialStore store = new HashicorpVaultCredentialStore();
-        assertThrows(CredentialStoreException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> store.initialize(null, createProtectionParameter("token"), new Provider[]{}));
     }
 


### PR DESCRIPTION
Changes
  - pom.xml: Added wildfly-common dependency
  - HashicorpVaultCredentialStore.java: Use Assert for attributes parameter
  - JwtConfig.java: Use Assert for constructor parameters
  - VaultAlias.java: Use Assert in create() method
  - VaultKeyPathOperations.java: Use Assert for data parameter
  
  Fixes #73  